### PR TITLE
fix: bump trace to fix missing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-trace-bom</artifactId>
-        <version>0.109.0-beta</version>
+        <version>0.109.3-beta</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://github.com/googleapis/java-trace/issues/35 was made and released in the trace bom a while ago, so I expected `google-cloud-bom` to also pick it up by now, but it looks like it's still using an old trace bom. I somehow thought these updates are automatic, but I guess not. Is it ok to update the trace bom version to release that fix to `google-cloud-bom` users?