### PR TITLE
chore: drop alpha version from release tag

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-bom:0.122.5-alpha:0.122.6-alpha-SNAPSHOT
+google-cloud-bom:0.122.5:0.122.6-SNAPSHOT


### PR DESCRIPTION
The next release version will be `0.123.0` rather than `0.123.0-alpha`