### PR TITLE
chore: use bom versioning strategy for releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,2 @@
-releaseType: java-yoshi
+releaseType: java-bom
 bumpMinorPreMajor: true

--- a/synth.py
+++ b/synth.py
@@ -21,4 +21,5 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 java.common_templates(excludes=[
   'README.md',
   'samples/*',
+  '.github/release-please.yml',
 ])


### PR DESCRIPTION
This should tell release-please to look at the dependencies being updated and bump the minor version of this artifact if any dependency bumped its minor version.
