### PR TITLE
feat: add dashboard for shared dependency version checking

### DIFF
--- a/.kokoro/nightly/dashboard.cfg
+++ b/.kokoro/nightly/dashboard.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the periodic build bash script in git.
+build_file: "java-cloud-bom/.kokoro/nightly/dashboard.sh"
+
+action {
+  define_artifacts {
+    regex: "**/target/com.google.cloud/**"
+    strip_prefix: "github/java-cloud-bom/dashboard/target"
+  }
+}

--- a/.kokoro/nightly/dashboard.sh
+++ b/.kokoro/nightly/dashboard.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+# Display commands being run.
+set -x
+
+cd github/java-cloud-bom
+# M2_HOME is not used since Maven 3.5.0 https://maven.apache.org/docs/3.5.0/release-notes.html
+mvn -B clean install
+
+# Running target of dashboard submodule
+# https://stackoverflow.com/questions/3459928/running-a-specific-maven-plugin-goal-from-the-command-line-in-a-sub-module-of-a/26448447#26448447
+# https://stackoverflow.com/questions/11091311/maven-execjava-goal-on-a-multi-module-project
+cd dashboard
+
+# For all versions available in Maven Central and local repository
+mvn -B exec:java -Dexec.mainClass="com.google.cloud.tools.opensource.cloudbomdashboard.DashboardMain" \
+  -Dexec.arguments="-a com.google.cloud:google-cloud-bom"

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,7 @@
+To generate the dashboard from the root directory run:
+
+```
+$ mvn clean install
+$ cd dashboard
+$ mvn exec:java -Dexec.arguments="-f ../pom.xml"
+```

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools</groupId>
+    <artifactId>dependencies-parent</artifactId>
+    <version>1.4.4-SNAPSHOT</version>
+  </parent>
+  <artifactId>google-cloud-bom-dashboard</artifactId>
+
+  <name>Cloud Tools Open Source Code Hygiene Dashboard</name>
+  <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/dashboard</url>
+  <organization>
+    <name>Google LLC.</name>
+    <url>https://www.google.com</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>2.3.30</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>dependencies</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>xom</groupId>
+      <artifactId>xom</artifactId>
+      <version>1.3.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <mainClass>com.google.cloud.tools.opensource.cloudbomdashboard.DashboardMain</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**/*.css</include>
+          <include>**/*.js</include>
+          <include>**/*.xml</include>
+          <include>**/*.ftl</include>
+        </includes>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
+  </build>
+
+</project>

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactCache.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.cloudbomdashboard;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.artifact.Artifact;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+
+/**
+ * Unified return type to bundle a lot of information  about multiple artifacts together.
+ */
+class ArtifactCache {
+
+  private Map<Artifact, ArtifactInfo> infoMap;
+  private List<DependencyGraph> globalDependencies;
+
+  void setInfoMap(Map<Artifact, ArtifactInfo> infoMap) {
+    this.infoMap = infoMap;
+  }
+
+  void setGlobalDependencies(List<DependencyGraph> globalDependencies) {
+    this.globalDependencies = globalDependencies;
+  }
+
+  Map<Artifact, ArtifactInfo> getInfoMap() {
+    return infoMap;
+  }
+
+  List<DependencyGraph> getGlobalDependencies() {
+    return globalDependencies;
+  }
+
+}

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactInfo.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.cloudbomdashboard;
+
+import org.eclipse.aether.RepositoryException;
+
+import com.google.cloud.tools.opensource.dependencies.DependencyGraph;
+
+/** 
+ * Cache of info looked up for an artifact.
+ */
+class ArtifactInfo {
+
+  private DependencyGraph completeDependencies;
+  private DependencyGraph transitiveDependencies;
+  private RepositoryException exception;
+
+  ArtifactInfo(DependencyGraph completeDependencies,
+      DependencyGraph transitiveDependencies) {
+    this.completeDependencies = completeDependencies;
+    this.transitiveDependencies = transitiveDependencies;
+  }
+
+  ArtifactInfo(RepositoryException ex) {
+    this.exception = ex;
+  }
+
+  DependencyGraph getCompleteDependencies() {
+    return completeDependencies;
+  }
+
+  DependencyGraph getTransitiveDependencies() {
+    return transitiveDependencies;
+  }
+
+  RepositoryException getException() {
+    return exception;
+  }
+
+}

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactResults.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/ArtifactResults.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.cloudbomdashboard;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.aether.artifact.Artifact;
+
+import com.google.cloud.tools.opensource.dependencies.Artifacts;
+
+/**
+ * Collection of test results for a single artifact.
+ */
+public final class ArtifactResults {
+
+  private final Map<String, Integer> results = new HashMap<>();
+  private final Artifact artifact;
+  private String exceptionMessage;
+
+  public ArtifactResults(Artifact artifact) {
+    this.artifact = artifact;
+  }
+
+  public void setExceptionMessage(String exceptionMessage) {
+    this.exceptionMessage = exceptionMessage;
+  }
+
+  void addResult(String testName, int failures) {
+    results.put(testName, failures);
+  }
+
+  /**
+   * @return true for pass, false for fail, null for unknown test
+   */
+  @Nullable
+  public Boolean getResult(String testName) {
+    Integer failures = results.get(testName);
+    if (failures != null) {
+      return failures == 0;
+    }
+    return null;
+  }
+
+  public String getCoordinates() {
+    return Artifacts.toCoordinates(artifact);
+  }
+
+  /**
+   *  @return message of exception occurred when running test, null for no exception
+   */
+  @Nullable
+  public String getExceptionMessage() {
+    return exceptionMessage;
+  }
+
+  /**
+   * 
+   * @return number of times the specified test failed. Returns 0
+   *     if the test was not run.
+   */
+  public int getFailureCount(String testName) {
+    Integer failures = results.get(testName);
+    if (failures == null) {
+      return 0;
+    }
+    return failures;
+  }
+}

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/DashboardArguments.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/DashboardArguments.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.cloudbomdashboard;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.annotation.Nullable;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Command-line option for {@link DashboardMain}. The tool takes either a pom.xml file path or Maven
+ * coordinates for a BOM.
+ */
+final class DashboardArguments {
+  private static final Options options = configureOptions();
+  private static final HelpFormatter helpFormatter = new HelpFormatter();
+
+  private final CommandLine commandLine;
+
+  private DashboardArguments(CommandLine commandLine) {
+    this.commandLine = commandLine;
+  }
+
+  /**
+   * Returns true if the argument for a file is specified. False if the argument for coordinates is
+   * specified.
+   *
+   * <p>It is guaranteed that either a file path or Maven coordinates for a BOM are available.
+   */
+  boolean hasFile() {
+    return commandLine.hasOption('f');
+  }
+
+  /**
+   * Returns true if the argument for a versionless coordinates is specified; otherwise false.
+   *
+   * <p>It is guaranteed that either a file path or Maven coordinates for a BOM are available.
+   */
+  boolean hasVersionlessCoordinates() {
+    return commandLine.hasOption('a');
+  }
+
+  /** Returns an absolute path to pom.xml file of a BOM. Null if file is not specified. */
+  @Nullable
+  Path getBomFile() {
+    if (!commandLine.hasOption('f')) {
+      return null;
+    }
+    // Trim the value so that maven exec plugin can pass arguments with exec.arguments="-f pom.xml"
+    return Paths.get(commandLine.getOptionValue('f').trim()).toAbsolutePath();
+  }
+
+  /** Returns the Maven coordinates of a BOM. Null if coordinates are not specified. */
+  @Nullable
+  String getBomCoordinates() {
+    if (!commandLine.hasOption('c')) {
+      return null;
+    }
+    return commandLine.getOptionValue('c').trim();
+  }
+
+  /**
+   * Returns the versionless Maven coordinates of a BOM. Null if versionless coordinates are not
+   * specified.
+   */
+  @Nullable
+  String getVersionlessCoordinates() {
+    if (!commandLine.hasOption('a')) {
+      return null;
+    }
+    return commandLine.getOptionValue('a').trim();
+  }
+
+  static DashboardArguments readCommandLine(String... arguments) throws ParseException {
+    CommandLineParser parser = new DefaultParser();
+
+    try {
+      // Throws ParseException if required option group ('-f' or '-c') is not specified
+      return new DashboardArguments(parser.parse(options, arguments));
+    } catch (ParseException ex) {
+      helpFormatter.printHelp("DashboardMain", options);
+      throw ex;
+    }
+  }
+
+  private static Options configureOptions() {
+    Options options = new Options();
+    OptionGroup inputGroup = new OptionGroup();
+    inputGroup.setRequired(true);
+
+    Option inputFileOption =
+        Option.builder("f").longOpt("bom-file").hasArg().desc("File to a BOM (pom.xml)").build();
+    inputGroup.addOption(inputFileOption);
+
+    Option inputCoordinatesOption =
+        Option.builder("c")
+            .longOpt("bom-coordinates")
+            .hasArg()
+            .desc(
+                "Maven coordinates of a BOM. For example, com.google.cloud:libraries-bom:1.0.0")
+            .build();
+    inputGroup.addOption(inputCoordinatesOption);
+
+    Option versionlessCoordinatesOption =
+        Option.builder("a")
+            .longOpt("all-versions")
+            .hasArg()
+            .desc(
+                "Maven coordinates of a BOM without version. "
+                    + "For example, com.google.cloud:libraries-bom")
+            .build();
+    inputGroup.addOption(versionlessCoordinatesOption);
+
+    options.addOptionGroup(inputGroup);
+    return options;
+  }
+}

--- a/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/DashboardMain.java
+++ b/dashboard/src/main/java/com/google/cloud/tools/opensource/cloudbomdashboard/DashboardMain.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.opensource.cloudbomdashboard;
+
+
+import com.google.cloud.tools.opensource.dependencies.*;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import freemarker.template.*;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class DashboardMain {
+
+  public static final String basePath = "https://repo1.maven.org/maven2";
+  public static final String TEST_NAME_UPPER_BOUND = "Upper Bounds";
+  public static final String TEST_NAME_DEPENDENCY_CONVERGENCE = "Dependency Convergence";
+
+  private static final Configuration freemarkerConfiguration = configureFreemarker();
+
+  private static final DependencyGraphBuilder dependencyGraphBuilder = new DependencyGraphBuilder();
+
+  /**
+   * Generates a code hygiene dashboard for a BOM. This tool takes a path to pom.xml of the BOM as
+   * an argument or Maven coordinates to a BOM.
+   *
+   * <p>Generated dashboard is at {@code target/$groupId/$artifactId/$version/index.html}, where
+   * each value is from BOM coordinates except {@code $version} is "snapshot" if the BOM has
+   * snapshot version.
+   */
+  public static void main(String[] arguments)
+      throws IOException, TemplateException, RepositoryException, URISyntaxException,
+      ParseException, MavenRepositoryException {
+    DashboardArguments dashboardArguments = DashboardArguments.readCommandLine(arguments);
+
+    if (dashboardArguments.hasVersionlessCoordinates()) {
+      generateAllVersions(dashboardArguments.getVersionlessCoordinates());
+    } else if (dashboardArguments.hasFile()) {
+      generate(dashboardArguments.getBomFile());
+    } else {
+      generate(dashboardArguments.getBomCoordinates());
+    }
+  }
+
+  private static void generateAllVersions(String versionlessCoordinates)
+      throws IOException, TemplateException, RepositoryException, URISyntaxException,
+      MavenRepositoryException {
+    List<String> elements = Splitter.on(':').splitToList(versionlessCoordinates);
+    checkArgument(
+        elements.size() == 2,
+        "The versionless coordinates should have one colon character: " + versionlessCoordinates);
+    String groupId = elements.get(0);
+    String artifactId = elements.get(1);
+
+    RepositorySystem repositorySystem = RepositoryUtility.newRepositorySystem();
+    ImmutableList<String> versions =
+        RepositoryUtility.findVersions(repositorySystem, groupId, artifactId);
+    for (String version : versions) {
+      if (version.contains("alpha")) continue;
+      generate(String.format("%s:%s:%s", groupId, artifactId, version));
+    }
+    generateVersionIndex(groupId, artifactId, versions);
+  }
+
+  @VisibleForTesting
+  static Path generateVersionIndex(String groupId, String artifactId, List<String> versions)
+      throws IOException, TemplateException, URISyntaxException {
+    Path directory = outputDirectory(groupId, artifactId, "snapshot").getParent();
+    directory.toFile().mkdirs();
+    Path page = directory.resolve("index.html");
+
+    Map<String, Object> templateData = new HashMap<>();
+    templateData.put("versions", versions);
+    templateData.put("groupId", groupId);
+    templateData.put("artifactId", artifactId);
+
+    File dashboardFile = page.toFile();
+    try (Writer out =
+        new OutputStreamWriter(new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
+      Template dashboard = freemarkerConfiguration.getTemplate("/templates/version_index.ftl");
+      dashboard.process(templateData, out);
+    }
+
+    copyResource(directory, "css/dashboard.css");
+
+    return page;
+  }
+
+  @VisibleForTesting
+  static Path generate(String bomCoordinates)
+      throws IOException, TemplateException, RepositoryException, URISyntaxException {
+    Path output = generate(Bom.readBom(bomCoordinates));
+    System.out.println("Wrote dashboard for " + bomCoordinates + " to " + output);
+    return output;
+  }
+
+  @VisibleForTesting
+  static Path generate(Path bomFile)
+      throws IOException, TemplateException, URISyntaxException, MavenRepositoryException {
+    checkArgument(Files.isRegularFile(bomFile), "The input BOM %s is not a regular file", bomFile);
+    checkArgument(Files.isReadable(bomFile), "The input BOM %s is not readable", bomFile);
+    Path output = generate(Bom.readBom(bomFile));
+
+    System.out.println("Wrote dashboard for " + bomFile + " to " + output);
+    return output;
+  }
+
+  private static Path generate(Bom bom) throws IOException, TemplateException, URISyntaxException {
+    List<Artifact> managedDependencies = new ArrayList<>();
+    for (Artifact artifact : bom.getManagedDependencies()) {
+      if ("com.google.cloud".equals(artifact.getGroupId())
+              && !artifact.getArtifactId().contains("google-cloud-core")) {
+        managedDependencies.add(artifact);
+      }
+    }
+
+    ArtifactCache cache = loadArtifactInfo(managedDependencies);
+    Path output = generateHtml(bom, cache);
+
+    return output;
+  }
+
+  private static Path outputDirectory(String groupId, String artifactId, String version) {
+    String versionPathElement = version.contains("-SNAPSHOT") ? "snapshot" : version;
+    return Paths.get("target", groupId, artifactId, versionPathElement);
+  }
+
+  private static Path generateHtml(
+      Bom bom,
+      ArtifactCache cache
+      )
+      throws IOException, TemplateException, URISyntaxException {
+
+    Artifact bomArtifact = new DefaultArtifact(bom.getCoordinates());
+
+    Path relativePath =
+        outputDirectory(
+            bomArtifact.getGroupId(), bomArtifact.getArtifactId(), bomArtifact.getVersion());
+    Path output = Files.createDirectories(relativePath);
+
+    copyResource(output, "css/dashboard.css");
+    copyResource(output, "js/dashboard.js");
+
+    List<ArtifactResults> table = generateReports(cache);
+    generateDashboard(output, table, cache, bom);
+
+    return output;
+  }
+
+  private static void copyResource(Path output, String resourceName)
+      throws IOException, URISyntaxException {
+    ClassLoader classLoader = DashboardMain.class.getClassLoader();
+    Path input = Paths.get(Objects.requireNonNull(classLoader.getResource(resourceName)).toURI()).toAbsolutePath();
+    Path copy = output.resolve(input.getFileName());
+    if (!Files.exists(copy)) {
+      Files.copy(input, copy);
+    }
+  }
+
+  @VisibleForTesting
+  static Configuration configureFreemarker() {
+    Configuration configuration = new Configuration(new Version("2.3.28"));
+    configuration.setDefaultEncoding("UTF-8");
+    configuration.setClassForTemplateLoading(DashboardMain.class, "/");
+    return configuration;
+  }
+
+  @VisibleForTesting
+  static List<ArtifactResults> generateReports(ArtifactCache cache) {
+
+    Map<Artifact, ArtifactInfo> artifacts = cache.getInfoMap();
+    List<ArtifactResults> table = new ArrayList<>();
+    for (Entry<Artifact, ArtifactInfo> entry : artifacts.entrySet()) {
+      ArtifactInfo info = entry.getValue();
+      if (info.getException() != null) {
+        ArtifactResults unavailable = new ArtifactResults(entry.getKey());
+        unavailable.setExceptionMessage(info.getException().getMessage());
+        table.add(unavailable);
+      } else {
+        Artifact artifact = entry.getKey();
+        ArtifactResults results =
+            generateArtifactReport(
+                artifact,
+                entry.getValue());
+        table.add(results);
+      }
+    }
+    return table;
+  }
+
+  /**
+   * This is the only method that queries the Maven repository.
+   */
+  private static ArtifactCache loadArtifactInfo(List<Artifact> artifacts) {
+    Map<Artifact, ArtifactInfo> infoMap = new LinkedHashMap<>();
+    List<DependencyGraph> globalDependencies = new ArrayList<>();
+
+    for (Artifact artifact : artifacts) {
+      DependencyGraph completeDependencies =
+          dependencyGraphBuilder.buildVerboseDependencyGraph(artifact);
+      globalDependencies.add(completeDependencies);
+
+      // picks versions according to Maven rules
+      DependencyGraph transitiveDependencies =
+          dependencyGraphBuilder.buildMavenDependencyGraph(new Dependency(artifact, "compile"));
+
+      ArtifactInfo info = new ArtifactInfo(completeDependencies, transitiveDependencies);
+      infoMap.put(artifact, info);
+    }
+
+    ArtifactCache cache = new ArtifactCache();
+    cache.setInfoMap(infoMap);
+    cache.setGlobalDependencies(globalDependencies);
+
+    return cache;
+  }
+
+  private static ArtifactResults generateArtifactReport(
+      Artifact artifact,
+      ArtifactInfo artifactInfo)
+  {
+    // includes all versions
+    DependencyGraph graph = artifactInfo.getCompleteDependencies();
+    List<Update> convergenceIssues = graph.findUpdates();
+
+    // picks versions according to Maven rules
+    DependencyGraph transitiveDependencies = artifactInfo.getTransitiveDependencies();
+
+    Map<Artifact, Artifact> upperBoundFailures =
+        findUpperBoundsFailures(graph.getHighestVersionMap(), transitiveDependencies);
+    ArtifactResults results = new ArtifactResults(artifact);
+    results.addResult(TEST_NAME_UPPER_BOUND, upperBoundFailures.size());
+    results.addResult(TEST_NAME_DEPENDENCY_CONVERGENCE, convergenceIssues.size());
+    return results;
+  }
+
+  private static Map<Artifact, Artifact> findUpperBoundsFailures(
+      Map<String, String> expectedVersionMap,
+      DependencyGraph transitiveDependencies) {
+
+    Map<String, String> actualVersionMap = transitiveDependencies.getHighestVersionMap();
+
+    VersionComparator comparator = new VersionComparator();
+
+    Map<Artifact, Artifact> upperBoundFailures = new LinkedHashMap<>();
+
+    for (String id : expectedVersionMap.keySet()) {
+      String expectedVersion = expectedVersionMap.get(id);
+      String actualVersion = actualVersionMap.get(id);
+      // Check that the actual version is not null because it is
+      // possible for dependencies to appear or disappear from the tree
+      // depending on which version of another dependency is loaded.
+      // In both cases, no action is needed.
+      if (actualVersion != null && comparator.compare(actualVersion, expectedVersion) < 0) {
+        // Maven did not choose highest version
+        DefaultArtifact lower = new DefaultArtifact(id + ":" + actualVersion);
+        DefaultArtifact upper = new DefaultArtifact(id + ":" + expectedVersion);
+        upperBoundFailures.put(lower, upper);
+      }
+    }
+    return upperBoundFailures;
+  }
+
+
+  @VisibleForTesting
+  static void generateDashboard(
+          Path output,
+          List<ArtifactResults> table,
+          ArtifactCache cache,
+          Bom bom)
+          throws IOException, TemplateException {
+    TreeSet<String> artifacts = new TreeSet<>();
+    Map<String, String> currentVersion = new HashMap<>();
+    Map<String, String> currentPomURL = new HashMap<>();
+    Map<String, String> newestVersion = new HashMap<>();
+    Map<String, String> newestPomURL = new HashMap<>();
+    Map<String, String> sharedDepsVersion = new HashMap<>();
+    Map<String, String> updatedTime = new HashMap<>();
+    Map<String, String> metadataURL = new HashMap<>();
+    Map<Artifact, ArtifactInfo> infoMap = cache.getInfoMap();
+    for (Map.Entry<Artifact, ArtifactInfo> info : infoMap.entrySet()) {
+      String artifactId = info.getKey().getArtifactId();
+      String groupId = info.getKey().getGroupId();
+      String version = info.getKey().getVersion();
+      artifacts.add(artifactId);
+      currentVersion.put(artifactId,version);
+      currentPomURL.put(artifactId, getPomFileURL(groupId, artifactId, version));
+      newestVersion.put(artifactId, latestVersion(info.getKey()));
+      newestPomURL.put(artifactId, getPomFileURL(groupId, artifactId, newestVersion.get(artifactId)));
+      sharedDepsVersion.put(artifactId, sharedDependencyVersion(info.getKey()));
+      updatedTime.put(artifactId, updatedTime(info.getKey()));
+      metadataURL.put(artifactId, getMetadataURL(info.getKey()));
+    }
+
+    Map<String, Object> templateData = new HashMap<>();
+    templateData.put("table", table);
+    templateData.put("lastUpdated", LocalDateTime.now());
+    templateData.put("currentVersion", currentVersion);
+    templateData.put("currentPomURL", currentPomURL);
+    templateData.put("newestVersion", newestVersion);
+    templateData.put("newestPomURL", newestPomURL);
+    templateData.put("sharedDepsVersion", sharedDepsVersion);
+    templateData.put("updatedTime", updatedTime);
+    templateData.put("metadataURL", metadataURL);
+    templateData.put("artifacts", artifacts);
+    templateData.put("coordinates", bom.getCoordinates());
+    templateData.put("dependencyGraphs", cache.getGlobalDependencies());
+
+    // Accessing static methods from Freemarker template
+    // https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#autoid_60
+    DefaultObjectWrapper wrapper = new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_28)
+        .build();
+    TemplateHashModel staticModels = wrapper.getStaticModels();
+    templateData.put("dashboardMain", staticModels.get(DashboardMain.class.getName()));
+
+    File dashboardFile = output.resolve("index.html").toFile();
+    try (Writer out = new OutputStreamWriter(
+        new FileOutputStream(dashboardFile), StandardCharsets.UTF_8)) {
+      Template dashboard = DashboardMain.freemarkerConfiguration.getTemplate("/templates/index.ftl");
+      dashboard.process(templateData, out);
+    }
+  }
+
+  private static String latestVersion(Artifact artifact) {
+    String pomPath = getMetadataURL(artifact);
+    try {
+      URL url = new URL(pomPath);
+      Scanner s = new Scanner(url.openStream());
+      while (s.hasNextLine()) {
+        String string = s.nextLine();
+        if (string.contains("<latest>")) {
+          return string.split(">")[1].split("<")[0];
+        }
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return "";
+  }
+
+  private static String updatedTime(Artifact artifact) {
+    String groupPath = artifact.getGroupId().replace('.', '/');
+    String metadataPath = basePath + "/" + groupPath
+            + "/" + artifact.getArtifactId()
+            + "/maven-metadata.xml";
+    try {
+      URL url = new URL(metadataPath);
+      Scanner s = new Scanner(url.openStream());
+      while (s.hasNextLine()) {
+        String string = s.nextLine();
+        if (string.contains("<lastUpdated>")) {
+          DateFormat dateFormat = new SimpleDateFormat("yyyyMMddhhmmss");
+          DateFormat outputFormat = new SimpleDateFormat("MM-dd-yyyy");
+          String input =  string.split(">")[1].split("<")[0];
+          Date date= dateFormat.parse(input);
+          return outputFormat.format(date);
+        }
+      }
+    } catch (IOException | java.text.ParseException e) {
+      e.printStackTrace();
+    }
+    return "";
+  }
+
+  /**
+   * Returns the number of rows in {@code table} that show unavailable ({@code null} result) or some
+   * failures for {@code columnName}.
+   */
+  public static long countFailures(List<ArtifactResults> table, String columnName) {
+    return table.stream()
+        .filter(row -> row.getResult(columnName) == null || row.getFailureCount(columnName) > 0)
+        .count();
+  }
+
+  private static String sharedDependencyVersion(Artifact artifact) {
+    String groupPath = artifact.getGroupId().replace('.', '/');
+    String pomPath = getPomFileURL(artifact.getGroupId(), artifact.getArtifactId(),artifact.getVersion());
+    String parentPath = basePath + "/" + groupPath
+            + "/" + artifact.getArtifactId() + "-parent"
+            + "/" + artifact.getVersion()
+            + "/" + artifact.getArtifactId() + "-parent-" + artifact.getVersion() + ".pom";
+    String depsBomPath = basePath + "/" + groupPath
+            + "/" + artifact.getArtifactId() + "-deps-bom"
+            + "/" + artifact.getVersion()
+            + "/" + artifact.getArtifactId() + "-deps-bom-" + artifact.getVersion() + ".pom";
+    String version = getSharedDepsVersionFromURL(parentPath);
+    if (version != null)
+      return version;
+    version = getSharedDepsVersionFromURL(pomPath);
+    if (version != null)
+      return version;
+    version = getSharedDepsVersionFromURL(depsBomPath);
+    if (version != null)
+      return version;
+    return "";
+  }
+  private static String getSharedDepsVersionFromURL(String pomURL)  {
+    File file = new File("pomFile.xml");
+    try {
+      URL url = new URL(pomURL);
+      FileUtils.copyURLToFile(url, file);
+      MavenXpp3Reader read = new MavenXpp3Reader();
+      Model model = read.read(new FileReader(file));
+      if (model.getDependencyManagement() == null)
+        return null;
+      for (org.apache.maven.model.Dependency dep : model.getDependencyManagement().getDependencies()) {
+        if ("com.google.cloud".equals(dep.getGroupId()) && "google-cloud-shared-dependencies".equals(dep.getArtifactId()))
+          return dep.getVersion();
+      }
+
+    } catch (XmlPullParserException | IOException ignored){}
+    file.deleteOnExit();
+    return null;
+  }
+
+  private static String getPomFileURL(String groupId, String artifactId, String version) {
+    String groupPath = groupId.replace('.', '/');
+    return basePath + "/" + groupPath
+            + "/" + artifactId
+            + "/" + version
+            + "/" + artifactId + "-" + version + ".pom";
+  }
+
+  private static String getMetadataURL(Artifact artifact) {
+    String groupPath = artifact.getGroupId().replace('.', '/');
+    return basePath + "/" + groupPath
+            + "/" + artifact.getArtifactId()
+            + "/maven-metadata.xml";
+  }
+}
+

--- a/dashboard/src/main/resources/css/dashboard.css
+++ b/dashboard/src/main/resources/css/dashboard.css
@@ -1,0 +1,147 @@
+body {
+  font-family: "Poppins", sans-serif;
+  font-weight: 400;
+  line-height: 1.625;
+  margin-left: 2em;
+}
+
+h1,
+h2,
+h3 {
+  color: #333333;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.2;
+  margin-top: 1ex;
+  margin-bottom: 1ex;
+}
+
+h1 {
+  font-size: 3em;
+}
+
+h2 {
+  font-size: 2.5em;
+}
+
+h3 {
+  font-size: 2em;
+}
+
+th, td {
+  padding: 5pt;
+}
+
+pre {
+  line-height: normal;
+}
+
+.pass {
+  background-color: lightgreen;
+  font-weight: bold;
+}
+
+.fail {
+  background-color: pink;
+  font-weight: bold;
+}
+
+.unavailable {
+  background-color: gray;
+  font-weight: bold;
+}
+
+p.dependency-tree-node {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.linkage-check-dependency-paths, .jar-linkage-report {
+  margin-left: 1em;
+}
+
+p.jar-linkage-report-cause {
+  margin-bottom: 0;
+  margin-left: 2em;
+}
+
+ul.jar-linkage-report-cause {
+  margin-top: 0;
+  margin-left: 3em;
+}
+
+ul.jar-linkage-report-cause > li {
+  font: 1em 'Droid Sans Mono', monospace;
+}
+
+ /* ----- Statistic ----- */
+.statistics {
+  padding-top: 50px;
+}
+
+.container {
+  min-height: 20ex;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.statistic-item {
+  flex: 0 0 16em;
+  padding: 1.6em 2.5em;
+  position: relative;
+  min-height: 180px;
+  overflow: hidden;
+  margin-bottom: 40px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0px 10px 20px 0px rgba(0, 0, 0, 0.03);
+  margin: 1em;
+  margin-left: unset;
+  margin-right: 2em;
+}
+
+.statistic-item .desc {
+  font-size: 1.15em;
+  text-transform: uppercase;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.statistic-item h2 {
+  font-size: 2.3em;
+  font-weight: 300;
+  color: #fff;
+}
+
+.statistic-item-green {
+  background: #00b26f;
+}
+
+.statistic-item-orange {
+  background: #ff8300;
+}
+
+.statistic-item-blue {
+  background: #00b5e9;
+}
+
+.statistic-item-red {
+  background: #fa4251;
+}
+
+.statistic-item-yellow {
+  background: #f1c40f;
+}
+
+#piecharts th {
+  vertical-align: top;
+}
+
+#piecharts td {
+  vertical-align: top;
+}
+
+.pie {
+  "text-align: center" 
+}

--- a/dashboard/src/main/resources/js/dashboard.js
+++ b/dashboard/src/main/resources/js/dashboard.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Toggles the visibility of source class list below the button.
+ * @param button clicked button element
+ */
+function toggleSourceClassListVisibility(button) {
+  const classList = button.parentElement.nextElementSibling;
+  const currentVisibility = classList.style.display !== "none";
+  const nextVisibility = !currentVisibility;
+  classList.style.display = nextVisibility ? "" : "none";
+  button.innerText = nextVisibility ? "▼" : "▶";
+}

--- a/dashboard/src/main/resources/poms/demo.xml
+++ b/dashboard/src/main/resources/poms/demo.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.google.cloud</groupId>
+	<artifactId>demo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>demo-pom</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${dependencyGroupId}</groupId>
+			<artifactId>${dependencyArtifactId}</artifactId>
+			<version>${dependencyVersion}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	<build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <rules>
+            <dependencyConvergence />
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/dashboard/src/main/resources/templates/index.ftl
+++ b/dashboard/src/main/resources/templates/index.ftl
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <#include "macros.ftl">
+  <head>
+    <meta charset="utf-8" />
+    <title>Google Cloud Platform Java Open Source Dependency Dashboard</title>
+    <link rel="stylesheet" href="dashboard.css" />
+    <script src="dashboard.js"></script>
+  </head>
+  <body>
+    <h1>${coordinates} Dependency Status</h1>
+    <hr />
+    <#assign totalArtifacts = table?size>
+    
+    <section class="statistics">
+      <div class="container">
+        <div class="statistic-item statistic-item-green">
+          <h2>${table?size}</h2>
+          <span class="desc">Total Artifacts Checked</span>
+        </div>
+
+        <div class="statistic-item statistic-item-orange">
+          <#assign localUpperBoundsErrorCount = dashboardMain.countFailures(table, "Upper Bounds")>
+          <h2>${dashboardMain.countFailures(table, "Upper Bounds")}</h2>
+          <span class="desc">${(localUpperBoundsErrorCount == 1)?then("Has", "Have")} Upper Bounds Errors</span>
+        </div>
+
+        <div class="statistic-item statistic-item-blue">
+          <#assign convergenceErrorCount = dashboardMain.countFailures(table, "Dependency Convergence")>
+          <h2>${dashboardMain.countFailures(table, "Dependency Convergence")}</h2>
+          <span class="desc">${(convergenceErrorCount == 1)?then("Fails", "Fail")} to Converge</span>
+        </div>
+      </div>
+    </section>
+
+    <h2>Library Versions</h2>
+      
+    <table id="library versions">
+      <tr>
+        <th>artifact</th>
+        <th>version in google-cloud-bom</th>
+        <th>latest released version</th>
+        <th>latest released date</th>
+        <th>version of google-cloud-shared-dependencies</th>
+      </tr>
+      <#list artifacts as artifact>
+        <tr>
+          <th>${artifact}</th>
+          <th><a target="_blank" href=${currentPomURL[artifact]}>${currentVersion[artifact]}</a></th>
+          <th><a target="_blank" href=${newestPomURL[artifact]}>${newestVersion[artifact]}</a></th>
+          <th><a target="_blank" href=${metadataURL[artifact]}>${updatedTime[artifact]}</a></th>
+          <th>${sharedDepsVersion[artifact]}</th>
+        </tr>
+      </#list>
+    </table>
+
+    <hr />
+
+    <p id='updated'>Last generated at ${lastUpdated}</p>
+  </body>
+</html>

--- a/dashboard/src/main/resources/templates/macros.ftl
+++ b/dashboard/src/main/resources/templates/macros.ftl
@@ -1,0 +1,112 @@
+<#function pluralize number singularNoun pluralNoun>
+  <#local plural = number gt 1 />
+  <#return number + " " + plural?string(pluralNoun, singularNoun)>
+</#function>
+<!-- same as above but without the number -->
+<#function plural number singularNoun pluralNoun>
+  <#local plural = number gt 1 />
+  <#return plural?string(pluralNoun, singularNoun)>
+</#function>
+
+<#macro formatJarLinkageReport classPathEntry problemsWithClass classPathResult dependencyPathRootCauses>
+  <!-- problemsWithClass: ImmutableSetMultimap<SymbolProblem, String> converted to
+    ImmutableMap<SymbolProblem, Collection<String>> to get key and set of values in Freemarker -->
+  <#assign problemsToClasses = problemsWithClass.asMap() />
+  <#assign symbolProblemCount = problemsToClasses?size />
+  <#assign referenceCount = 0 />
+  <#list problemsToClasses?values as classes>
+    <#assign referenceCount += classes?size />
+  </#list>
+
+  <h3>${classPathEntry?html}</h3>
+  <p class="jar-linkage-report">
+    ${pluralize(symbolProblemCount, "target class", "target classes")}
+    causing linkage errors referenced from
+    ${pluralize(referenceCount, "source class", "source classes")}.
+  </p>
+  <#assign jarsInProblem = {} >
+  <#list problemsToClasses as symbolProblem, sourceClasses>
+    <#if (symbolProblem.getContainingClass())?? >
+      <!-- Freemarker's hash requires its keys to be string.
+      https://freemarker.apache.org/docs/app_faq.html#faq_nonstring_keys -->
+      <#assign jarsInProblem = jarsInProblem
+        + { symbolProblem.getContainingClass().getClassPathEntry().toString() :  symbolProblem.getContainingClass().getClassPathEntry() } >
+    </#if>
+    <p class="jar-linkage-report-cause">${symbolProblem?html}, referenced from ${
+      pluralize(sourceClasses?size, "class", "classes")?html}
+      <button onclick="toggleSourceClassListVisibility(this)"
+              title="Toggle visibility of source class list">▶
+      </button>
+    </p>
+
+    <!-- The visibility of this list is toggled via the button above. Hidden by default -->
+    <ul class="jar-linkage-report-cause" style="display:none">
+      <#list sourceClasses as sourceClass>
+        <li>${sourceClass?html}</li>
+      </#list>
+    </ul>
+  </#list>
+  <#list jarsInProblem?values as jarInProblem>
+    <@showDependencyPath dependencyPathRootCauses classPathResult jarInProblem />
+  </#list>
+  <@showDependencyPath dependencyPathRootCauses classPathResult classPathEntry />
+
+</#macro>
+
+<#macro showDependencyPath dependencyPathRootCauses classPathResult classPathEntry>
+  <#assign dependencyPaths = classPathResult.getDependencyPaths(classPathEntry) />
+  <p class="linkage-check-dependency-paths">
+    The following ${plural(dependencyPaths?size, "path contains", "paths contain")} ${classPathEntry?html}:
+  </p>
+
+  <#if dependencyPathRootCauses[classPathEntry]?? >
+    <p class="linkage-check-dependency-paths">${dependencyPathRootCauses[classPathEntry]?html}
+    </p>
+  <#else>
+    <ul class="linkage-check-dependency-paths">
+        <#list dependencyPaths as dependencyPath >
+          <li>${dependencyPath}</li>
+        </#list>
+    </ul>
+  </#if>
+</#macro>
+
+<#macro formatDependencyGraph graph node parent>
+  <#if node == graph.getRootPath() >
+      <#assign label = 'root' />
+  <#else>
+      <#assign label = 'parent: ' + parent.getLeaf() />
+  </#if>
+  <p class="dependency-tree-node" title="${label}">${node.getLeaf()}</p>
+  <ul>
+    <#list graph.getChildren(node) as childNode>
+      <#if node != childNode>
+        <li class="dependency-tree-node">
+            <@formatDependencyGraph graph childNode node />
+        </li>
+      </#if>
+    </#list>
+  </ul>
+</#macro>
+
+<#macro testResult row name>
+  <#if row.getResult(name)?? ><#-- checking isNotNull() -->
+  <#-- When it's not null, the test ran. It's either PASS or FAIL -->
+    <#assign test_label = row.getResult(name)?then('PASS', 'FAIL')>
+    <#assign failure_count = row.getFailureCount(name)>
+  <#else>
+  <#-- Null means there's an exception and test couldn't run -->
+    <#assign test_label = "UNAVAILABLE">
+  </#if>
+  <td class='${test_label?lower_case}' title="${row.getExceptionMessage()!""}">
+    <#if row.getResult(name)?? >
+      <#assign page_anchor =  name?replace(" ", "-")?lower_case />
+      <a href="${row.getCoordinates()?replace(":", "_")}.html#${page_anchor}">
+        <#if failure_count gt 0>${pluralize(failure_count, "FAILURE", "FAILURES")}
+        <#else>PASS
+        </#if>
+      </a>
+    <#else>UNAVAILABLE
+    </#if>
+  </td>
+</#macro>

--- a/dashboard/src/main/resources/templates/version_index.ftl
+++ b/dashboard/src/main/resources/templates/version_index.ftl
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>${groupId}:${artifactId}</title>
+  <link rel="stylesheet" href="dashboard.css" />
+</head>
+<body>
+<h1>${groupId}:${artifactId}</h1>
+
+<ul>
+  <#list versions as version>
+    <li>
+      <a href="${version?contains('-SNAPSHOT')?then('snapshot', version)}/index.html">${version}</a>
+    </li>
+  </#list>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Overview:
We intend to use google-cloud-shared-dependencies for all the libraries in the google-cloud-bom. To avoid dependency conflict, we want to make sure the versions of google-cloud-shared-dependencies in all the libraries are the same before we actually release the bom.  So we try to build a dashboard for google-cloud-bom to show the version of google-cloud-shared-dependencies in the libraries of google-cloud-bom.

Goals:

1. Calculate the number of libraries in the google-cloud-bom and show them
2. Count the number of libraries where upper bounds errors occur
3. Count the number of libraries who fail to converge
4. Show the version of libraries in the bom and the latest version released in the Maven Center with release date.
5. Show the version of google-cloud-shared-dependencies in the library
6. Add link to the resources of data
7. Add build date of dashboard
8. Generate the result for released and snapshot of the google-cloud-bom
9. Deploy and run it at scheduled time

@stephaniewang526  @chingor13 