### PR TITLE
chore: specify repo settings overrides in local configuration

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -40,4 +40,10 @@ branchProtectionRules:
     - "Kokoro - Test: Integration"
     - "cla/google"
 # List of explicit permissions to add (additive only)
-permissionRules: []
+permissionRules:
+- team: yoshi-admins
+  permission: admin
+- team: yoshi-java-admins
+  permission: admin
+- team: yoshi-java
+  permission: push

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,43 @@
+# Whether or not squash-merging is enabled on this repository.
+# Defaults to `true`
+rebaseMergeAllowed: false
+
+# Whether or not rebase-merging is enabled on this repository.
+# Defaults to `true`
+squashMergeAllowed: true
+
+# Whether or not PRs are merged with a merge commit on this repository.
+# Defaults to `false`
+mergeCommitAllowed: false
+
+# Rules for master branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: master
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: true
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "Kokoro - Test: BOM Upper Bounds"
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
+# List of explicit permissions to add (additive only)
+permissionRules: []


### PR DESCRIPTION
See https://github.com/googleapis/repo-automation-bots/pull/754

Required status check configs can now be configured locally. 
