### PR TITLE
chore: not to require up to date branches

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -25,7 +25,7 @@ branchProtectionRules:
   # Defaults to `false`
   requiresCodeOwnerReviews: true
   # Require up to date branches
-  requiresStrictStatusChecks: true
+  requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - "Kokoro - Test: BOM Upper Bounds"


### PR DESCRIPTION
to stop the delay in merging many PRs