### PR TITLE
build: run bom-upper-bounds check on GitHub actions

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,7 +28,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "Kokoro - Test: BOM Upper Bounds"
+    - "bom-upper-bounds"
     - "dependencies (8)"
     - "dependencies (11)"
     - "linkage-monitor"
@@ -37,7 +37,6 @@ branchProtectionRules:
     - "units (7)"
     - "units (8)"
     - "units (11)"
-    - "Kokoro - Test: Integration"
     - "cla/google"
 # List of explicit permissions to add (additive only)
 permissionRules:

--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,2 +1,1 @@
-trustedContributors:
-- renovate-bot
+trustedContributors: []

--- a/.github/workflows/bom-upper-bounds.yaml
+++ b/.github/workflows/bom-upper-bounds.yaml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: ci
+jobs:
+  bom-upper-bounds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .kokoro/bom-upper-bounds-check.sh
+        env:
+          JOB_TYPE: test

--- a/.github/workflows/bom-upper-bounds.yaml
+++ b/.github/workflows/bom-upper-bounds.yaml
@@ -13,6 +13,7 @@ jobs:
         with:
           java-version: 8
       - run: java -version
+      - run: sudo apt-get install libxml2-utils
       - run: .kokoro/bom-upper-bounds-check.sh
         env:
           JOB_TYPE: test

--- a/synth.py
+++ b/synth.py
@@ -23,5 +23,6 @@ java.common_templates(excludes=[
   'samples/*',
   '.github/release-please.yml',
     # excluding samples ci jobs since there are no samples in this repo
-  '.github/workflows/samples.yaml'
+  '.github/workflows/samples.yaml',
+  '.github/trusted-contribution.yml',
 ])


### PR DESCRIPTION
This should allow us to stop requiring Kokoro at all - we don't actually have any integration tests to run here and the upper-bounds-check can happen on GitHub actions.