### PR TITLE
deps: update google-cloud-compute to 0.119.4-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute</artifactId>
-        <version>1.0.1-alpha</version>
+        <version>0.119.4-alpha</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
We're not ready to switch users to google-cloud-compute 1.0.0 (diregapic client).