### PR TITLE
chore: add back needed dashboard dependencies

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -33,6 +33,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>2.3.31</version>
+    </dependency>
+    <dependency>
       <!-- required to create PlexusContainer in RepositoryUtility-->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
@@ -77,6 +82,11 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.6.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Add back some dependencies accidentally removed in #1665 for building the dashboard and the dashboard report.

