### PR TITLE
ci: java-cloud-bom to have its own upper-bound check

### DIFF
--- a/.github/workflows/bom-upper-bounds.yaml
+++ b/.github/workflows/bom-upper-bounds.yaml
@@ -13,7 +13,12 @@ jobs:
         with:
           java-version: 8
       - run: java -version
-      - run: sudo apt-get install libxml2-utils
-      - run: .kokoro/bom-upper-bounds-check.sh
-        env:
-          JOB_TYPE: test
+      - name: Install Google Cloud BOM
+        run: |
+          mvn -B -V -ntp install
+      # This check is similar to the Libraries BOM's check in the downstream.
+      # https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/boms/upper-bounds-check/pom.xml
+      - name: Validate upper-bound of library dependencies in the Google Cloud BOM
+        run: |
+          mvn -B -V -ntp validate
+        working-directory: upper-bounds-check

--- a/upper-bounds-check/pom.xml
+++ b/upper-bounds-check/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud</groupId>
+  <artifactId>upper-bounds-check</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Cloud Platform Supported Libraries Upper Bounds Check</name>
+  <description>
+    Import the Google Cloud BOM in a simple project and verify that each library imported is the
+    most recent of the versions available in the dependency tree. This check is similar to the
+    Library BOM's check:
+    https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/boms/upper-bounds-check/pom.xml
+  </description>
+
+  <organization>
+    <name>Google LLC</name>
+    <url>https://cloud.google.com</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>0.153.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <rules>
+            <requireUpperBoundDeps />
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
The current upper-bounds check runs cloud-opensource-java (the Libraries BOM's repository, one of downstream of google-cloud-bom)'s check. When it fails, it's usually the Libraries BOM having old artifacts. However, **it's not google-cloud-bom's responsibility to keep other parts of the Libraries BOM, such as google-cloud-core and gRPC versions**. Therefore, this PR moves the check from cloud-opensource-java to java-cloud-bom. It checks the upper-bounds for a simple project that uses google-cloud-storage and google-cloud-pubsub.


# What about "Kokoro - Test: BOM Upper Bounds"?

Let's remove it (https://github.com/googleapis/java-cloud-bom/issues/1659). Not in this PR.


----

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-cloud-bom/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
