### PR TITLE
ci: removing upper bounds check from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,7 +28,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "bom-upper-bounds"
     - "dependencies (8)"
     - "dependencies (11)"
     - "linkage-monitor"


### PR DESCRIPTION
As per https://github.com/googleapis/java-cloud-bom/pull/1940#issuecomment-828558092, I'm deleting the upper-bounds check from this repository. This is the first step of removing the upper bounds check in this repository.

<img width="882" alt="Screen Shot 2021-04-28 at 16 20 17" src="https://user-images.githubusercontent.com/28604/116467458-b189c680-a83d-11eb-8c2d-4af6e2b25a9b.png">

Once the "required" mark is gone, I'll delete the files in #1942.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-cloud-bom/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
