### PR TITLE
feat: add newly promoted libraries to google-cloud-bom

### DIFF
--- a/dependency-convergence/pom.xml
+++ b/dependency-convergence/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud:current} -->
+        <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dependency-convergence/pom.xml
+++ b/dependency-convergence/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>full-convergence-check</artifactId>
   <packaging>pom</packaging>
-  <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud:current} -->
+  <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
   <name>Full convergence check for all library dependencies in Google Cloud Java BOM</name>
   <description>
     BOM for Full convergence check on google-cloud-java

--- a/dependency-convergence/pom.xml
+++ b/dependency-convergence/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>full-convergence-check</artifactId>
   <packaging>pom</packaging>
-  <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
+  <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud:current} -->
   <name>Full convergence check for all library dependencies in Google Cloud Java BOM</name>
   <description>
     BOM for Full convergence check on google-cloud-java
@@ -23,17 +23,25 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.156.1-SNAPSHOT</version><!-- {x-version-update:google-cloud:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-accessapproval</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-aiplatform</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-api-gateway</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -85,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-compute-bom</artifactId>
+      <artifactId>google-cloud-compute</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -125,6 +133,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-dms</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-dns</artifactId>
     </dependency>
     <dependency>
@@ -137,6 +149,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-essential-contacts</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-firestore</artifactId>
     </dependency>
     <dependency>
@@ -146,6 +162,10 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-game-servers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-gsuite-addons</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -267,7 +287,19 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-security-private-ca</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-service-management</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-service-usage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-shell</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -299,6 +331,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-tpu</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-trace</artifactId>
     </dependency>
     <dependency>
@@ -315,11 +351,19 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-vpcaccess</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-websecurityscanner</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-webrisk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-workflow-executions</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,15 @@
         <role>Developer</role>
       </roles>
     </developer>
+    <developer>
+      <id>neenushaji</id>
+      <name>Neenu Shaji</name>
+      <email>neenushaji@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
   </developers>
   <organization>
     <name>Google</name>
@@ -164,6 +173,13 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-accessapproval-bom</artifactId>
         <version>1.1.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-aiplatform-bom</artifactId>
+        <version>1.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -260,6 +276,8 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute-bom</artifactId>
         <version>1.2.0-alpha</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
@@ -326,6 +344,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-dms-bom</artifactId>
+        <version>0.1.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dns</artifactId>
         <version>1.2.1</version>
       </dependency>
@@ -340,6 +365,13 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-errorreporting-bom</artifactId>
         <version>0.121.3-beta</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-essential-contacts-bom</artifactId>
+        <version>0.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -364,6 +396,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-gsuite-addons-bom</artifactId>
+        <version>0.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-iamcredentials-bom</artifactId>
@@ -542,6 +582,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-security-private-ca-bom</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-servicedirectory-bom</artifactId>
         <version>1.2.5</version>
         <type>pom</type>
@@ -551,6 +598,20 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-service-management-bom</artifactId>
         <version>1.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-service-usage-bom</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-shell-bom</artifactId>
+        <version>0.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -601,6 +662,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-tpu-bom</artifactId>
+        <version>0.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-trace-bom</artifactId>
         <version>1.4.1</version>
         <type>pom</type>
@@ -629,6 +697,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-vpcaccess-bom</artifactId>
+        <version>0.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-websecurityscanner-bom</artifactId>
         <version>1.2.1</version>
         <type>pom</type>
@@ -638,6 +713,13 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-webrisk-bom</artifactId>
         <version>1.2.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-workflow-executions-bom</artifactId>
+        <version>1.0.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Added the following libraries:
- java-dms
- java-essential-contacts
- java-aiplatform
- java-gsuite-addons
- java-service-usage
- java-workflow-executions
- java-api-gateway
- java-shell
- java-tpu
- java-vpcaccess
