### PR TITLE
revert: "feat: add google-cloud-logging-servlet-initializer"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,11 +467,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-logging-servlet-initializer</artifactId>
-        <version>0.1.3-alpha</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-mediatranslation-bom</artifactId>
         <version>0.7.5</version>
         <type>pom</type>


### PR DESCRIPTION
Reverts googleapis/java-cloud-bom#3496

We should not include any new non-stable APIs in this BOM