### PR TITLE
fix(test): excluding checker-compat-qual from full convergence test

### DIFF
--- a/dependency-convergence/pom.xml
+++ b/dependency-convergence/pom.xml
@@ -27,6 +27,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Excluding checking the version of this artifact because it's build-
+        time dependency and should not cause problems in users' environments -->
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-compat-qual</artifactId>
+        <version>2.5.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Before

```
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (enforce) @ full-convergence-check ---
[WARNING] 
Dependency convergence error for com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile paths to dependency are:
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-artifact-registry:jar:1.1.0:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-asset:jar:3.2.15:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
...
[WARNING] 
Dependency convergence error for org.checkerframework:checker-compat-qual:jar:2.5.5:compile paths to dependency are:
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-bigquery:jar:2.9.4:compile
    +-org.checkerframework:checker-compat-qual:jar:2.5.5:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-pubsublite:jar:1.4.12:compile
    +-org.checkerframework:checker-compat-qual:jar:2.5.3:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-security-private-ca:jar:2.2.4:compile
    +-org.checkerframework:checker-compat-qual:jar:2.5.5:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-spanner:jar:6.21.1:compile
    +-org.checkerframework:checker-compat-qual:jar:2.5.5:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-spanner-jdbc:jar:2.6.1:compile
    +-org.checkerframework:checker-compat-qual:jar:2.5.5:compile

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.951 s
[INFO] Finished at: 2022-03-10T10:47:07-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0:enforce (enforce) on project full-convergence-check: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> 
```

# After

It only shows the proto-google-iam-v1 problem:

```
~/java-cloud-bom/dependency-convergence $ mvn verify                                            git[branch:exclude_checker-qual]
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------< com.google.cloud:full-convergence-check >---------------
[INFO] Building Full convergence check for all library dependencies in Google Cloud Java BOM 0.170.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (enforce) @ full-convergence-check ---
[WARNING] 
Dependency convergence error for com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile paths to dependency are:
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-artifact-registry:jar:1.1.0:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-asset:jar:3.2.15:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-bigquery:jar:2.9.4:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-bigqueryconnection:jar:2.2.0:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-bigquerystorage:jar:2.10.1:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
and
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-bigtable:jar:2.6.0:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile
...
+-com.google.cloud:full-convergence-check:pom:0.170.1-SNAPSHOT
  +-com.google.cloud:google-cloud-translate:jar:2.1.11:compile
    +-com.google.api.grpc:proto-google-iam-v1:jar:1.2.6:compile

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```