### PR TITLE
build: try to enable maven-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,5 +10,8 @@
     "libraries-bom": {
       "component": "libraries-bom"
     }
-  }
+  },
+  "plugins": [
+    "maven-workspace"
+  ]
 }


### PR DESCRIPTION
This enables the maven-workspace plugin so a release for google-cloud-bom will bump its version in libraries-bom