### PR TITLE
deps(libraries-bom): use library versions from the shared dependencies BOM 2.12.0

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -52,7 +52,7 @@
     <google.cloud.core.version>2.7.1</google.cloud.core.version>
     <io.grpc.version>1.46.0</io.grpc.version>
     <http.version>1.41.8</http.version>
-    <protobuf.version>3.21.0</protobuf.version>
+    <protobuf.version>3.20.1</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
     <gax.version>2.18.1</gax.version>
@@ -60,7 +60,7 @@
     <auth.version>1.7.0</auth.version>
     <api-common.version>2.2.0</api-common.version>
     <common.protos.version>2.8.3</common.protos.version>
-    <iam.protos.version>1.4.0</iam.protos.version>
+    <iam.protos.version>1.3.4</iam.protos.version>
   </properties>
 
   <distributionManagement>

--- a/owlbot.py
+++ b/owlbot.py
@@ -29,5 +29,6 @@ java.common_templates(
         ".github/workflows/samples.yaml",
         ".github/trusted-contribution.yml",
         ".github/workflows/auto-release.yaml",
+        "renovate.json"
     ]
 )

--- a/renovate.json
+++ b/renovate.json
@@ -70,5 +70,8 @@
     }
   ],
   "semanticCommits": true,
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "ignorePaths": [
+    "libraries-bom"
+  ]
 }


### PR DESCRIPTION
https://github.com/googleapis/java-shared-dependencies/blob/v2.12.0/first-party-dependencies/pom.xml

The Libraries BOM should not give the latest versions to our library users. Rather, it should give the versions in the corresponding shared dependencies BOM. The versions of the shared dependencies BOM 2.12.0 are the core library versions that we built and tested for the client libraries.

There's a planned enhancement for phase 2 where the Libraries BOM use the first-party-dependencies BOM (a part of the shared dependencies BOM).