### PR TITLE
ci: bom-content-test as required. libraries-bom to use snapshot

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,6 +15,7 @@ branchProtectionRules:
       - units (8)
       - units (11)
       - cla/google
+      - bom-content-test
   - pattern: java7
     isAdminEnforced: true
     requiredApprovingReviewCount: 1

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.174.0</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.174.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Making bom-content-test as required
- The Libraries BOM should use snapshot for bom-content-test
