### PR TITLE
ci: bump-minor-pre-major in the config file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "packages": {
     "google-cloud-bom": {
       "component": "google-cloud-bom",
-      "bumpMinorPreMajor": true
+      "bump-minor-pre-major": true
     },
     "libraries-bom": {
       "component": "libraries-bom"


### PR DESCRIPTION
As per @chingor13  and https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile, the option is "bump-minor-pre-major".

Fixes https://github.com/googleapis/release-please/issues/1462