### PR TITLE
deps: libraries-bom update with shared dependencies BOM 2.13.0

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -46,18 +46,18 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.1-jre</guava.version>
     <gson.version>2.9.0</gson.version>
-    <google.cloud.core.version>2.7.1</google.cloud.core.version>
-    <io.grpc.version>1.46.0</io.grpc.version>
-    <http.version>1.41.8</http.version>
-    <protobuf.version>3.20.1</protobuf.version>
+    <google.cloud.core.version>2.8.0</google.cloud.core.version>
+    <io.grpc.version>1.47.0</io.grpc.version>
+    <http.version>1.42.0</http.version>
+    <protobuf.version>3.21.1</protobuf.version>
     <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
         When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.18.1</gax.version>
-    <gax.httpjson.version>0.103.1</gax.httpjson.version>
+    <gax.version>2.18.2</gax.version>
+    <gax.httpjson.version>0.103.2</gax.httpjson.version>
     <auth.version>1.7.0</auth.version>
-    <api-common.version>2.2.0</api-common.version>
-    <common.protos.version>2.8.3</common.protos.version>
-    <iam.protos.version>1.3.4</iam.protos.version>
+    <api-common.version>2.2.1</api-common.version>
+    <common.protos.version>2.9.0</common.protos.version>
+    <iam.protos.version>1.4.1</iam.protos.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Libraries BOM update with the shared dependencies BOM 2.13.0
https://github.com/googleapis/java-shared-dependencies/blob/v2.13.0/third-party-dependencies/pom.xml

https://search.maven.org/artifact/com.google.api/gax-bom/2.18.2/pom
has gax-httpjson 0.103.2.
