### PR TITLE
feat!: preparing for next release

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -25,13 +25,13 @@
   </developers>
 
   <issueManagement>
-    <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues</url>
+    <url>https://github.com/googleapis/java-cloud-bom/issues</url>
   </issueManagement>
   <scm>
-    <connection>scm:git:git@github.com:GoogleCloudPlatform/cloud-opensource-java.git</connection>
-    <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/cloud-opensource-java.git
+    <connection>scm:git:git@github.com:googleapis/java-cloud-bom.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-cloud-bom.git
     </developerConnection>
-    <url>https://github.com/GoogleCloudPlatform/cloud-opensource-java/boms/cloud-oss-bom</url>
+    <url>https://github.com/googleapis/java-cloud-bom</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/tests/dependency-convergence/pom.xml
+++ b/tests/dependency-convergence/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.175.0</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.176.0</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
google-cloud-dataproc had a major version bump (v4). This pull request bumps the libraries BOM version to accomodate the change. Until Release Please can take care of the major version bump via google-cloud-bom, we maintain the version manually.

tests/dependency-convergence/pom.xml needs to reference the next version to resolve the failing check https://github.com/googleapis/java-cloud-bom/pull/4502#issuecomment-1177547876