### PR TITLE
build: Release Please to control tests module too

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,10 @@
     },
     "libraries-bom": {
       "component": "libraries-bom"
+    },
+    "tests": {
+      "component": "tests",
+      "bump-minor-pre-major": true
     }
   },
   "plugins": [

--- a/tests/dependency-convergence/pom.xml
+++ b/tests/dependency-convergence/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>full-convergence-check</artifactId>
   <packaging>pom</packaging>
-  <version>0.175.0</version><!-- {x-version-update:google-cloud-bom:current} -->
+  <version>0.176.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
   <name>Full convergence check for all library dependencies in Google Cloud Java BOM</name>
   <description>
     BOM for Full convergence check on google-cloud-java
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.176.0</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.176.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release Please updates the versions listed in the manifest only (Related: https://github.com/googleapis/release-please/issues/1453). The tests module is not touched by Release Please. This pull request attempts to include the module into the scope of Release Please

# The Problem to Solve

Because of this gap, currently the tests/dependency-convergence module fails when we create a new version:

```
[INFO] Scanning for projects...
Error: ] Some problems were encountered while processing the POMs:
Error:  'dependencies.dependency.version' for com.google.cloud:google-cloud-datastream:jar is missing. @ line 146, column 18
Error:  'dependencies.dependency.version' for com.google.cloud:google-cloud-dataplex:jar is missing. @ line 150, column 18
Error:  'dependencies.dependency.version' for com.google.cloud:google-cloud-optimization:jar is missing. @ line 285, column 17
 @ 
Error:  The build could not read 1 project -> [Help 1]
Error:    
Error:    The project com.google.cloud:full-convergence-check:0.174.0 (/home/runner/work/java-cloud-bom/java-cloud-bom/tests/dependency-convergence/pom.xml) has 3 errors
Error:      'dependencies.dependency.version' for com.google.cloud:google-cloud-datastream:jar is missing. @ line 146, column 18
Error:      'dependencies.dependency.version' for com.google.cloud:google-cloud-dataplex:jar is missing. @ line 150, column 18
Error:      'dependencies.dependency.version' for com.google.cloud:google-cloud-optimization:jar is missing. @ line 285, column 17
```

The error occurs in tests/dependency-convergence directory with `mvn -B -V -ntp validate`.

The google-cloud-bom version in the test pom.xml is not updated. https://github.com/googleapis/java-cloud-bom/blob/196198c62a720ff364e0b547c2f7a73783d884e5/tests/dependency-convergence/pom.xml#L26

It should have pointed to "0.175.0".