### PR TITLE
test: assert convergence among Cloud Java client libraries

### DIFF
--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -24,6 +24,24 @@ jobs:
         mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBomReachable"
       working-directory: tests
 
+  bom-assertion-test:
+    name: BomContentAssertionsTest (Test for assertion logic in BomContentTest)
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 8
+    - run: java -version
+    - name: Install Google Cloud BOM
+      run: |
+        mvn -B -V -ntp install
+    - run: |
+        mvn -B -V -ntp verify -Dtest="BomContentAssertionsTest"
+      working-directory: tests
+
   linkage-checker:
     name: Linkage Checker to find new linkage errors
     runs-on: ubuntu-latest

--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -6,27 +6,6 @@ on:
 name: ci
 jobs:
   bom-content-test:
-    name: Checking content of the Libraries BOM
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: zulu
-        java-version: 8
-    - run: java -version
-    - name: Install BOMs
-      run: |
-        mvn -B -V -ntp install
-    - name: Ensure the BOM has valid content
-      run: |
-        # BomContentTest should run part of the verify
-        mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBom"
-      working-directory: tests
-
-  libraries-bom-member-existence:
-    name: Checking Libraries BOM members exist in Maven Central
     runs-on: ubuntu-latest
     if: github.repository_owner == 'googleapis'
     steps:
@@ -41,8 +20,12 @@ jobs:
         mvn -B -V -ntp install
     - name: Ensure the BOM has valid content
       run: |
-        # BomContentTest should run part of the verify
         mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBomReachable"
+      working-directory: tests
+    - name: Ensure the BOM has valid content
+      if: github.head_ref == 'release-please--branches--main'
+      run: |
+        mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBom"
       working-directory: tests
 
   bom-assertion-test:

--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -116,5 +116,5 @@ jobs:
     - name: Ensure convergence among "google-cloud-*" libraries
       run: |
         # BomContentTest should run part of the verify
-        mvn -B -V -ntp verify -Dtest="BomContentTest#assertDependencyConvergenceWithinCloudJavaLibraries"
+        mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBOMCloudClientConvergence"
       working-directory: tests

--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -18,11 +18,11 @@ jobs:
     - name: Install BOMs
       run: |
         mvn -B -V -ntp install
-    - name: Ensure the BOM has valid content
+    - name: Ensure the members of the Libraries BOM exist in Maven Central
       run: |
         mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBomReachable"
       working-directory: tests
-    - name: Ensure the BOM has valid content
+    - name: Ensure the BOM has valid content (at releases)
       if: github.head_ref == 'release-please--branches--main'
       run: |
         mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBom"

--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -6,6 +6,27 @@ on:
 name: ci
 jobs:
   bom-content-test:
+    name: Checking content of the Libraries BOM
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 8
+    - run: java -version
+    - name: Install BOMs
+      run: |
+        mvn -B -V -ntp install
+    - name: Ensure the BOM has valid content
+      run: |
+        # BomContentTest should run part of the verify
+        mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBom"
+      working-directory: tests
+
+  libraries-bom-member-existence:
+    name: Checking Libraries BOM members exist in Maven Central
     runs-on: ubuntu-latest
     if: github.repository_owner == 'googleapis'
     steps:
@@ -15,7 +36,7 @@ jobs:
         distribution: zulu
         java-version: 8
     - run: java -version
-    - name: Install Google Cloud BOM
+    - name: Install BOMs
       run: |
         mvn -B -V -ntp install
     - name: Ensure the BOM has valid content
@@ -35,7 +56,7 @@ jobs:
         distribution: zulu
         java-version: 8
     - run: java -version
-    - name: Install Google Cloud BOM
+    - name: Install BOMs
       run: |
         mvn -B -V -ntp install
     - run: |
@@ -70,15 +91,30 @@ jobs:
         distribution: zulu
         java-version: 8
     - run: java -version
-    - name: Install Google Cloud BOM
+    - name: Install BOMs
       run: |
         mvn -B -V -ntp install
     - name: Validate dependency convergence of library dependencies in the Google Cloud BOM
       run: |
         mvn -B -V -ntp validate
       working-directory: tests/dependency-convergence
-    - name: Validate dependency convergence of library dependencies in the Google Cloud BOM
+
+  dependencies-convergence-cloud-client-libraries:
+    name: Checking convergence among "google-cloud-*" libraries (experimental)
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 8
+    - run: java -version
+    - name: Install BOMs
+      run: |
+        mvn -B -V -ntp install
+    - name: Ensure convergence among "google-cloud-*" libraries
       run: |
         # BomContentTest should run part of the verify
-        mvn -B -V -ntp verify -Dtest="BomContentTest#testLibrariesBom"
+        mvn -B -V -ntp verify -Dtest="BomContentTest#assertDependencyConvergenceWithinCloudJavaLibraries"
       working-directory: tests

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,6 +37,11 @@
       <version>1.5.12</version>
     </dependency>
     <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud;
+
+import com.google.cloud.tools.opensource.dependencies.Bom;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+/** Tests for the assertions in BomContentTest. */
+public class BomContentAssertionsTest {
+
+  @Test(expected = IOException.class)
+  public void testInvalidBomUnreachable() throws Exception {
+    Path bomPath =
+        Paths.get("src", "test", "resources", "bom-with-typo-artifact.xml").toAbsolutePath();
+    BomContentTest.checkBomReachable(bomPath);
+  }
+
+  @Test
+  public void testAssertDependencyConvergenceWithinCloudJavaLibraries() throws Exception {
+    Bom bom = Bom.readBom("com.google.cloud:libraries-bom:26.0.0");
+    try {
+      BomContentTest.assertDependencyConvergenceWithinCloudJavaLibraries(bom);
+      Assert.fail();
+    } catch (ComparisonFailure ex) {
+      String message = ex.getMessage();
+      Assert.assertEquals(
+          "Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency "
+              + "com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be 2.15.0 "
+              + "(the version in the BOM) expected:<2.1[5.0]> but was:<2.1[4.2]>",
+          message);
+    }
+  }
+
+  @Test
+  public void testAssertDependencyConvergenceWithinCloudJavaLibraries2() throws Exception {
+    Bom bom = Bom.readBom("com.google.cloud:libraries-bom:25.0.0");
+    try {
+      BomContentTest.assertDependencyConvergenceWithinCloudJavaLibraries(bom);
+      Assert.fail();
+    } catch (ComparisonFailure ex) {
+      String message = ex.getMessage();
+      Assert.assertEquals(
+          "Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency "
+              + "com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be 2.15.0 "
+              + "(the version in the BOM) expected:<2.1[5.0]> but was:<2.1[4.2]>",
+          message);
+    }
+  }
+}

--- a/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC.
+ * Copyright 2022 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentAssertionsTest.java
@@ -17,11 +17,11 @@
 package com.google.cloud;
 
 import com.google.cloud.tools.opensource.dependencies.Bom;
+import com.google.common.truth.Truth;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Assert;
-import org.junit.ComparisonFailure;
 import org.junit.Test;
 
 /** Tests for the assertions in BomContentTest. */
@@ -36,33 +36,18 @@ public class BomContentAssertionsTest {
 
   @Test
   public void testAssertDependencyConvergenceWithinCloudJavaLibraries() throws Exception {
+    // Our old BOM release had the problem of non-convergence.
     Bom bom = Bom.readBom("com.google.cloud:libraries-bom:26.0.0");
     try {
       BomContentTest.assertDependencyConvergenceWithinCloudJavaLibraries(bom);
       Assert.fail();
-    } catch (ComparisonFailure ex) {
+    } catch (AssertionError ex) {
       String message = ex.getMessage();
-      Assert.assertEquals(
-          "Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency "
-              + "com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be 2.15.0 "
-              + "(the version in the BOM) expected:<2.1[5.0]> but was:<2.1[4.2]>",
-          message);
-    }
-  }
-
-  @Test
-  public void testAssertDependencyConvergenceWithinCloudJavaLibraries2() throws Exception {
-    Bom bom = Bom.readBom("com.google.cloud:libraries-bom:25.0.0");
-    try {
-      BomContentTest.assertDependencyConvergenceWithinCloudJavaLibraries(bom);
-      Assert.fail();
-    } catch (ComparisonFailure ex) {
-      String message = ex.getMessage();
-      Assert.assertEquals(
-          "Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency "
-              + "com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be 2.15.0 "
-              + "(the version in the BOM) expected:<2.1[5.0]> but was:<2.1[4.2]>",
-          message);
+      Truth.assertThat(message)
+          .contains(
+              "Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency"
+                  + " com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be"
+                  + " 2.15.0 (the version in the BOM)");
     }
   }
 }

--- a/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -59,6 +59,12 @@ public class BomContentTest {
     checkBom(bomPath);
   }
 
+  @Test
+  public void testLibrariesBOMCloudClientConvergence() throws Exception {
+    Path bomPath = Paths.get("..", "libraries-bom", "pom.xml").toAbsolutePath();
+    assertDependencyConvergenceWithinCloudJavaLibraries(Bom.readBom(bomPath));
+  }
+
   private void checkBom(Path bomPath) throws Exception {
     Bom bom = Bom.readBom(bomPath);
     List<Artifact> artifacts = bom.getManagedDependencies();
@@ -69,7 +75,6 @@ public class BomContentTest {
     assertNoDowngradeRule(bom);
     assertUniqueClasses(artifacts);
     assertBomIsImported(bom);
-    assertDependencyConvergenceWithinCloudJavaLibraries(bom);
   }
 
   /**

--- a/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -343,6 +343,9 @@ public class BomContentTest {
     }
 
     if (!errorMessages.isEmpty()) {
+      errorMessages.add("\nThis means we are about to release an SDK ("+bom.getCoordinates()
+          +") and we did not test these combinations. "
+          +"Please update the dependencies of the libraries above and release them.");
       Assert.fail(Joiner.on(". ").join(errorMessages));
     }
   }

--- a/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -348,9 +348,11 @@ public class BomContentTest {
     }
 
     if (!errorMessages.isEmpty()) {
-      errorMessages.add("\nThis means we are about to release an SDK ("+bom.getCoordinates()
-          +") and we did not test these combinations. "
-          +"Please update the dependencies of the libraries above and release them.");
+      errorMessages.add(
+          "\nThis means we are about to release an SDK ("
+              + bom.getCoordinates()
+              + ") and we did not test these combinations. "
+              + "Please update the dependencies of the libraries above and release them.");
       Assert.fail(Joiner.on(". ").join(errorMessages));
     }
   }


### PR DESCRIPTION
The assertions on the dependency convergence among Cloud Java libraries:

```
Managed dependency com.google.cloud:google-cloud-bigquery:jar:2.13.8 has dependency com.google.cloud:google-cloud-bigquerystorage:jar:2.14.2, which should be 2.15.0 (the version in the BOM).
Managed dependency com.google.cloud:google-cloud-nio:jar:0.124.7 has dependency com.google.cloud:google-cloud-storage:jar:2.9.0, which should be 2.9.2 (the version in the BOM).
Managed dependency com.google.cloud:google-cloud-notification:jar:0.123.2-beta has dependency com.google.cloud:google-cloud-storage:jar:2.7.2, which should be 2.9.2 (the version in the BOM).
Managed dependency com.google.cloud:google-cloud-notification:jar:0.123.2-beta has dependency com.google.cloud:google-cloud-pubsub:jar:1.119.1, which should be 1.120.0 (the version in the BOM).
Managed dependency com.google.cloud:google-cloud-spanner-jdbc:jar:2.7.4 has dependency com.google.cloud:google-cloud-spanner:jar:6.25.5, which should be 6.25.7 (the version in the BOM).
Managed dependency com.google.cloud:google-cloud-pubsublite:jar:1.6.1 has dependency com.google.cloud:google-cloud-pubsub:jar:1.119.0, which should be 1.120.0 (the version in the BOM)
```

Fixes https://github.com/googleapis/java-cloud-bom/issues/3710
