### PR TITLE
deps: java-shared-dependencies 3.0.1 and using gax-bom

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -45,19 +45,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>31.1-jre</guava.version>
-    <gson.version>2.9.0</gson.version>
-    <google.cloud.core.version>2.8.0</google.cloud.core.version>
-    <io.grpc.version>1.47.0</io.grpc.version>
-    <http.version>1.42.0</http.version>
-    <protobuf.version>3.21.1</protobuf.version>
-    <!-- We don't use gax-bom because it includes the artifacts with 'testlib' classifier.
-        When updating gax.version, update gax.httpjson.version too. -->
-    <gax.version>2.18.2</gax.version>
-    <gax.httpjson.version>0.103.2</gax.httpjson.version>
-    <auth.version>1.7.0</auth.version>
+    <gson.version>2.9.1</gson.version>
+    <google.cloud.core.version>2.8.6</google.cloud.core.version>
+    <io.grpc.version>1.48.0</io.grpc.version>
+    <http.version>1.42.2</http.version>
+    <protobuf.version>3.21.4</protobuf.version>
+    <gax.version>2.18.7</gax.version>
+    <auth.version>1.8.1</auth.version>
     <api-common.version>2.2.1</api-common.version>
-    <common.protos.version>2.9.0</common.protos.version>
-    <iam.protos.version>1.4.1</iam.protos.version>
+    <common.protos.version>2.9.2</common.protos.version>
+    <iam.protos.version>1.5.2</iam.protos.version>
   </properties>
 
   <distributionManagement>
@@ -233,18 +230,10 @@
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
-        <artifactId>gax</artifactId>
+        <artifactId>gax-bom</artifactId>
         <version>${gax.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-grpc</artifactId>
-        <version>${gax.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-httpjson</artifactId>
-        <version>${gax.httpjson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.auth</groupId>


### PR DESCRIPTION
Setting versions for https://github.com/googleapis/java-shared-dependencies/blob/v3.0.1/third-party-dependencies/pom.xml.

From next release, the Libraries BOM start importing gax-bom. This will provide gax's testlib artifacts to users (https://github.com/googleapis/java-cloud-bom/issues/4694) as well as easing our maintenance of setting gax and gax-httpjson versions. With `mvn help:effective-pom`, I confirmed the GAX artifacts are available for BOM users:

```
suztomo@suztomo2:~/java-cloud-bom/libraries-bom$ mvn help:effective-pom |grep -A2 gax
    <gax.version>2.18.7</gax.version>
    <google.cloud.core.version>2.8.6</google.cloud.core.version>
    <gson.version>2.9.1</gson.version>
--
        <artifactId>gax</artifactId>
        <version>2.18.7</version>
      </dependency>
--
        <artifactId>gax</artifactId>
        <version>2.18.7</version>
        <classifier>testlib</classifier>
--
        <artifactId>gax-grpc</artifactId>
        <version>2.18.7</version>
      </dependency>
--
        <artifactId>gax-grpc</artifactId>
        <version>2.18.7</version>
        <classifier>testlib</classifier>
--
        <artifactId>gax-httpjson</artifactId>
        <version>0.103.7</version>
      </dependency>
--
        <artifactId>gax-httpjson</artifactId>
        <version>0.103.7</version>
        <classifier>testlib</classifier>
```