### PR TITLE
ci: skip-github-release for  the "tests/dependency-convergence" module

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
     },
     "tests/dependency-convergence": {
       "component": "tests-dependency-convergence",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "skip-github-release": true
     }
   },
   "plugins": [


### PR DESCRIPTION
skip-github-release for the "tests/dependency-convergence" module.

Using https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile:

```
        "skip-github-release": {
          "description": "Skip tagging GitHub releases for this package. Defaults to `false`.",
          "type": "boolean"
        },
```