### PR TITLE
deps: use first-party-dependencies in libraries-bom

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -44,17 +44,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <guava.version>31.1-jre</guava.version>
-    <gson.version>2.9.1</gson.version>
-    <google.cloud.core.version>2.8.6</google.cloud.core.version>
-    <io.grpc.version>1.48.0</io.grpc.version>
-    <http.version>1.42.2</http.version>
-    <protobuf.version>3.21.4</protobuf.version>
-    <gax.version>2.18.7</gax.version>
-    <auth.version>1.8.1</auth.version>
-    <api-common.version>2.2.1</api-common.version>
-    <common.protos.version>2.9.2</common.protos.version>
-    <iam.protos.version>1.5.2</iam.protos.version>
   </properties>
 
   <distributionManagement>
@@ -70,148 +59,15 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Not using Guava-bom because it includes guava-gwt, which has many invalid references -->
+      <!-- first-party-dependencies is part of google-cloud-shared-dependencies
+           BOM in https://github.com/googleapis/java-shared-dependencies/blob/main/first-party-dependencies/pom.xml.
+           This includes Guava, Protobuf, gRPC, Google Auth Libraries, etc. -->
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-testlib</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>${gson.version}</version>
-      </dependency>
-      <!-- protobufs from https://github.com/protocolbuffers/protobuf/tree/master/java -->
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-bom</artifactId>
-        <version>${protobuf.version}</version>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>first-party-dependencies</artifactId>
+        <version>3.0.3</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <!-- google-http-java-client from https://github.com/googleapis/google-http-java-client -->
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-android</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-apache-v2</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-appengine</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-gson</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-jackson2</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-protobuf</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-test</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-xml</artifactId>
-        <version>${http.version}</version>
-      </dependency>
-
-      <!-- GRPC; specifically https://github.com/grpc/grpc-java -->
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-alts</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-api</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-auth</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-context</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-core</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-grpclb</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-netty</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-netty-shaded</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-okhttp</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-protobuf</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-protobuf-lite</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-services</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-stub</artifactId>
-        <version>${io.grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-testing</artifactId>
-        <version>${io.grpc.version}</version>
       </dependency>
 
       <!-- google-cloud-java from https://github.com/googleapis/java-cloud-bom-->
@@ -222,54 +78,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>api-common</artifactId>
-        <version>${api-common.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>gax-bom</artifactId>
-        <version>${gax.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-bom</artifactId>
-        <version>${auth.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-core-bom</artifactId>
-        <version>${google.cloud.core.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-common-protos</artifactId>
-        <version>${common.protos.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-common-protos</artifactId>
-        <version>${common.protos.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-iam-v1</artifactId>
-        <version>${iam.protos.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-iam-v1</artifactId>
-        <version>${iam.protos.version}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/renovate.json
+++ b/renovate.json
@@ -70,8 +70,5 @@
     }
   ],
   "semanticCommits": true,
-  "dependencyDashboard": true,
-  "ignorePaths": [
-    "libraries-bom"
-  ]
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
With this pull request, we don't need to manually maintain the property values for the Google Core libraries.

Here is the comparison of the artifacts in before and after https://gist.github.com/suztomo/8da4e33c5ca501aae2d8fd645a7c305c (3 files). The diff of the two list shows that there's no artifacts removed by this change.

There are new additions because we start importing new BOMs, such as google-cloud-core-bom and grpc-bom. We used to declare some of the artifacts there independently, and thus other artifacts were not in the Libraries BOM. Now they're part of the Libraries BOM.


# Enabling RenovateBot

RenovateBot was turned off because latest versions are not guaranteed to be tested with Google Cloud client libraries. Now the versions in the first-party-dependencies are tested. We can rely on RenovateBot now.