### PR TITLE
test: exclude UnsafeNativeLong for duplicate class

### DIFF
--- a/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -138,10 +138,14 @@ public class BomContentTest {
       for (String className : classPathEntry.getFileNames()) {
         if (className.contains("javax.annotation")
             || className.contains("$")
+            || className.endsWith("package-info")
             || className.equals("com.google.cloud.location.LocationsGrpc")
-            || className.endsWith("package-info")) {
+            || className.equals("com.google.gwt.core.client.UnsafeNativeLong")
+            ) {
           // Ignore annotations, nested classes, and package-info files.
           // Ignore LocationsGrpc classes which are duplicated in generated grpc libraries.
+          // Ignore GWT's UnsafeNativeLong, which appear in om.google.gwt:gwt-dev:2.9.0 and
+          // com.google.jsinterop:base:1.0.0.
           continue;
         }
 


### PR DESCRIPTION
BOMContentTest is currently failing because a GWT class `com.google.gwt.core.client.UnsafeNativeLong` (https://github.com/googleapis/java-cloud-bom/pull/5124#issuecomment-1251057283) appears in multiple JAR files. Guava-GWT is added because we start using guava-bom in  #5125 . However GWT (the technology that works on browser) is not intended to communicate with Google Cloud through Cloud Java client library.

With this PR, the GWT classes (package "com.google.gwt") are excluded from the check. 
