### PR TITLE
deps: remove unnecesary artifacts in BOM

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -172,7 +172,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -183,13 +183,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bigquerydatatransfer-bom</artifactId>
-        <version>2.4.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerystorage-bom</artifactId>
         <version>2.23.1</version>
         <type>pom</type>
@@ -204,22 +197,8 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-datalabeling-bom</artifactId>
-        <version>0.124.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastore-bom</artifactId>
         <version>2.12.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-errorreporting-bom</artifactId>
-        <version>0.125.0-beta</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -244,22 +223,8 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-mediatranslation-bom</artifactId>
-        <version>0.10.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-nio</artifactId>
         <version>0.124.18</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-phishingprotection-bom</artifactId>
-        <version>0.35.0</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
google-cloud-gapic-libraries BOM 0.2.0 provides the versions of
these artifacts.
https://search.maven.org/artifact/com.google.cloud/gapic-libraries-bom/0.2.0/pom
