### PR TITLE
docs: README to reflect the BOM includes preview libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To use it in Maven, add the following to your POM:
 ```
 [//]: # ({x-version-update-end})
 
+[![Maven][maven-version-image]][maven-version-link]
+
 When you use the Libraries BOM, you don't specify individual library versions
 and your application runs on a consistent set of the dependencies.
 
@@ -60,3 +62,6 @@ Apache 2.0 - See [LICENSE] for more information.
 [LICENSE]: https://github.com/googleapis/google-cloud-java/blob/main/LICENSE
 [TESTING]: https://github.com/googleapis/google-cloud-java/blob/main/TESTING.md
 [cloud-platform]: https://cloud.google.com/
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/libraries-bom.svg
+[maven-version-link]: https://search.maven.org/artifact/com.google.cloud/libraries-bom
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use it in Maven, add the following to your POM:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.0.0</version>
+      <version>26.1.5</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -31,7 +31,7 @@ and your application runs on a consistent set of the dependencies.
 ## Libraries in Scope
 
 The content of the Libraries BOM consists of 2 categories:
-- stable Google Cloud Java client libraries and
+- Google Cloud Java client libraries (Maven coordinates `com.google.cloud:google-cloud-XXX`, where XXX is a GCP service name) and
 - core Google dependency libraries, such as gRPC, Protobuf, and Guava.
 
 ## Dependency Dashboard


### PR DESCRIPTION
With 26.1.5 BOM release, we include preview libraries in the Libraries BOM.


> With this release, we started including preview libraries to the BOM (version pre 1.0) into the Libraries BOM, so that Cloud customers can use both stable and preview Cloud Java libraries with consistent dependencies without dependency conflicts. For the distinction of stable and preview versions, please refer to https://github.com/googleapis/google-cloud-java/#versioning.

https://github.com/googleapis/java-cloud-bom/releases/tag/libraries-bom-v26.1.5