### PR TITLE
ci: removing Linkage Check

### DIFF
--- a/.github/workflows/full-convergence-check.yaml
+++ b/.github/workflows/full-convergence-check.yaml
@@ -46,24 +46,6 @@ jobs:
         mvn -B -V -ntp verify -Dtest="BomContentAssertionsTest"
       working-directory: tests
 
-  linkage-checker:
-    name: Linkage Checker to find new linkage errors
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: zulu
-        java-version: 8
-    - name: Install BOMs
-      run: |
-        mvn -B -V -ntp install
-    - name: Ensure the Libraries BOM does not contain new linkage errors
-      run: |
-        mvn -B -V -ntp test -Dtest="MaximumLinkageErrorsTest"
-      working-directory: tests
-
   full-dependencies-convergence:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'


### PR DESCRIPTION
Removing (failing) Linkage Check in favor of "shared-dependencies-convergence" check. As long as the client libraries use the shared dependencies and their tests pass, we won't encounter dependency conflicts.

Linkage Checker is known to report false positives such as https://github.com/googleapis/java-cloud-bom/issues/5161

Closes https://github.com/googleapis/java-cloud-bom/issues/5161

