### PR TITLE
chore: release note to show notable changes

### DIFF
--- a/.github/workflows/ci-release-note-generation.yaml
+++ b/.github/workflows/ci-release-note-generation.yaml
@@ -18,6 +18,8 @@ jobs:
       run: |
         mvn -B -ntp verify
       working-directory: release-note-generation
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   dry-run:
     runs-on: ubuntu-latest
@@ -36,6 +38,8 @@ jobs:
         mvn -B -ntp exec:java \
             -Dexec.args="com.google.cloud:libraries-bom:26.1.5"
       working-directory: release-note-generation
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Show generated release note
       shell: bash
       run: |

--- a/.github/workflows/release-note-generation.yaml
+++ b/.github/workflows/release-note-generation.yaml
@@ -49,6 +49,7 @@ jobs:
       working-directory: release-note-generation
       env:
         LIBRARIES_BOM_VERSION: ${{ steps.pick-version.outputs.libraries-bom-version }}
+        GH_TOKEN: ${{ github.token }}
     - name: Update the release note with release_note.md
       run: |
         TAG="libraries-bom-v${LIBRARIES_BOM_VERSION}"

--- a/release-note-generation/pom.xml
+++ b/release-note-generation/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -31,10 +31,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.io.Files;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -469,8 +467,8 @@ public class ReleaseNoteGeneration {
   }
 
   /**
-   * Returns the release note content of the release of {@code tag} of {@code owner}/
-   * {@code repository}.
+   * Returns the release note content of the release of {@code tag} of {@code owner}/ {@code
+   * repository}.
    */
   @VisibleForTesting
   static String fetchReleaseNote(String owner, String repository, String tag)
@@ -478,14 +476,12 @@ public class ReleaseNoteGeneration {
     // gh release --repo googleapis/java-storage view v2.16.0
 
     ProcessBuilder builder =
-        new ProcessBuilder("gh", "release", "--repo",owner + "/" + repository,
-            "view", tag);
+        new ProcessBuilder("gh", "release", "--repo", owner + "/" + repository, "view", tag);
     Process process = builder.start();
     String errorOutput = new String(process.getErrorStream().readAllBytes());
     boolean finished = process.waitFor(1, TimeUnit.MINUTES);
     Verify.verify(finished, "The process timed out");
-    Verify.verify(0 == process.exitValue(),
-        "The command failed: %s", errorOutput);
+    Verify.verify(0 == process.exitValue(), "The command failed: %s", errorOutput);
     String output = new String(process.getInputStream().readAllBytes());
     return output;
   }

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -515,7 +515,14 @@ public class ReleaseNoteGeneration {
                   fetchClientLibraryNotableChangeLog(splitRepoName, versionsForReleaseNotes);
               if (!changelog.isEmpty()) {
                 // Only print library name when there are notable changes
-                report.append("## ").append(artifactId).append("\n");
+                report
+                    .append("## ")
+                    .append(artifactId)
+                    .append(" ")
+                    .append(currentVersion)
+                    .append(" (prev: ")
+                    .append(previousVersion)
+                    .append(")");
                 report.append(changelog).append("\n");
               }
             } catch (MavenRepositoryException | IOException | InterruptedException ex) {

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -86,4 +86,15 @@ public class ReleaseNoteGenerationTest {
                 + "[v3.13.0](https://github.com/googleapis/java-logging/releases/tag/v3.13.0), "
                 + "[v3.13.1](https://github.com/googleapis/java-logging/releases/tag/v3.13.1))");
   }
+
+  @Test
+  public void testFetchReleaseNote() throws Exception {
+    String storageReleaseNote2_16_0 = ReleaseNoteGeneration.fetchReleaseNote("googleapis", "java-storage",
+        "v2.16.0");
+    Truth.assertThat(storageReleaseNote2_16_0)
+        .contains("* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and "
+            + "Bucket.RetentionPolicy.retention_duration "
+            + "([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
+            + "([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))");
+  }
 }

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -88,6 +88,9 @@ public class ReleaseNoteGenerationTest {
   }
 
   @Test
+  public void testReportClientLibrariesNotableChangeLogs() throws Exception {}
+
+  @Test
   public void testFetchClientLibraryNotableChangeLog() throws Exception {
     String notableChangelog =
         ReleaseNoteGeneration.fetchClientLibraryNotableChangeLog(
@@ -95,10 +98,10 @@ public class ReleaseNoteGenerationTest {
 
     // A new feature in 2.16.0
     Truth.assertThat(notableChangelog)
-        .contains("* Added a new retention_duration field of Duration type");
+        .contains("- Added a new retention_duration field of Duration type");
 
     // A bug fix in 2.15.1
-    Truth.assertThat(notableChangelog).contains("* Disable REGAPIC transport in storage v2");
+    Truth.assertThat(notableChangelog).contains("- Disable REGAPIC transport in storage v2");
 
     // A dependency update in 2.16.0. A dependency update is not notable.
     Truth.assertThat(notableChangelog).doesNotContain("native-maven-plugin");
@@ -117,6 +120,7 @@ public class ReleaseNoteGenerationTest {
             + " ([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))\n"
             + "* Added a new retention_duration field of Duration type"
             + " ([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))\n"
+            + "* Next release from main branch is 1.122.0\n"
             + "\n"
             + "\n"
             + "### Bug Fixes\n"
@@ -130,15 +134,20 @@ public class ReleaseNoteGenerationTest {
     String notableChangelog = ReleaseNoteGeneration.filterOnlyRelevantChangelog(rawChangelog);
     // A new feature in 2.16.0
     Truth.assertThat(notableChangelog)
-        .contains("* Added a new retention_duration field of Duration type");
+        .contains("- Added a new retention_duration field of Duration type");
 
     // A bug fix in 2.15.1
-    Truth.assertThat(notableChangelog).contains("* Disable REGAPIC transport in storage v2");
+    Truth.assertThat(notableChangelog).contains("- Disable REGAPIC transport in storage v2");
 
     // A dependency update in 2.16.0. A dependency update is not notable.
     Truth.assertThat(notableChangelog).doesNotContain("native-maven-plugin");
 
+    // The forced minor version upgrade is irrelevant to customer
+    Truth.assertThat(notableChangelog).doesNotContain("1.122.0");
+
     Truth.assertThat(notableChangelog).doesNotContainMatch("^$");
+    // The list item is replaced with "- "
+    Truth.assertThat(notableChangelog).doesNotContainMatch("^\\* ");
   }
 
   @Test

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -60,7 +60,7 @@ public class ReleaseNoteGenerationTest {
   @Test
   public void testPrintClientLibraryVersionDifference() throws Exception {
     ReleaseNoteGeneration generation = new ReleaseNoteGeneration();
-    generation.printClientLibraryVersionDifference(
+    generation.reportClientLibraryVersionDifference(
         ImmutableList.of(
             "com.google.cloud:google-cloud-redis", "com.google.cloud:google-cloud-logging"),
         ImmutableMap.of(
@@ -88,14 +88,68 @@ public class ReleaseNoteGenerationTest {
   }
 
   @Test
+  public void testFetchClientLibraryNotableChangeLog() throws Exception {
+    String notableChangelog =
+        ReleaseNoteGeneration.fetchClientLibraryNotableChangeLog(
+            "java-storage", ImmutableList.of("2.16.0", "2.15.1"));
+
+    // A new feature in 2.16.0
+    Truth.assertThat(notableChangelog)
+        .contains("* Added a new retention_duration field of Duration type");
+
+    // A bug fix in 2.15.1
+    Truth.assertThat(notableChangelog).contains("* Disable REGAPIC transport in storage v2");
+
+    // A dependency update in 2.16.0. A dependency update is not notable.
+    Truth.assertThat(notableChangelog).doesNotContain("native-maven-plugin");
+
+    Truth.assertThat(notableChangelog).doesNotContainMatch("^$");
+  }
+
+  @Test
+  public void testFilterOnlyRelevantChangelog() throws Exception {
+    String rawChangelog =
+        "### Features\n"
+            + "\n"
+            + "* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and"
+            + " Bucket.RetentionPolicy.retention_duration"
+            + " ([#1790](https://github.com/googleapis/java-storage/issues/1790))"
+            + " ([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))\n"
+            + "* Added a new retention_duration field of Duration type"
+            + " ([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))\n"
+            + "\n"
+            + "\n"
+            + "### Bug Fixes\n"
+            + "\n"
+            + "* Removed WriteObject routing annotations"
+            + " ([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))\n"
+            + "* Disable REGAPIC transport in storage v2\n"
+            + "\n"
+            + "\n"
+            + "### Documentation";
+    String notableChangelog = ReleaseNoteGeneration.filterOnlyRelevantChangelog(rawChangelog);
+    // A new feature in 2.16.0
+    Truth.assertThat(notableChangelog)
+        .contains("* Added a new retention_duration field of Duration type");
+
+    // A bug fix in 2.15.1
+    Truth.assertThat(notableChangelog).contains("* Disable REGAPIC transport in storage v2");
+
+    // A dependency update in 2.16.0. A dependency update is not notable.
+    Truth.assertThat(notableChangelog).doesNotContain("native-maven-plugin");
+
+    Truth.assertThat(notableChangelog).doesNotContainMatch("^$");
+  }
+
+  @Test
   public void testFetchReleaseNote() throws Exception {
     String storageReleaseNote2_16_0 =
         ReleaseNoteGeneration.fetchReleaseNote("googleapis", "java-storage", "v2.16.0");
     Truth.assertThat(storageReleaseNote2_16_0)
         .contains(
-            "* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and "
-                + "Bucket.RetentionPolicy.retention_duration "
-                + "([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
+            "* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and"
+                + " Bucket.RetentionPolicy.retention_duration"
+                + " ([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
                 + "([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))");
   }
 }

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -89,12 +89,13 @@ public class ReleaseNoteGenerationTest {
 
   @Test
   public void testFetchReleaseNote() throws Exception {
-    String storageReleaseNote2_16_0 = ReleaseNoteGeneration.fetchReleaseNote("googleapis", "java-storage",
-        "v2.16.0");
+    String storageReleaseNote2_16_0 =
+        ReleaseNoteGeneration.fetchReleaseNote("googleapis", "java-storage", "v2.16.0");
     Truth.assertThat(storageReleaseNote2_16_0)
-        .contains("* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and "
-            + "Bucket.RetentionPolicy.retention_duration "
-            + "([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
-            + "([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))");
+        .contains(
+            "* Add {Compose,Rewrite,StartResumableWrite}Request.object_checksums and "
+                + "Bucket.RetentionPolicy.retention_duration "
+                + "([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
+                + "([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))");
   }
 }


### PR DESCRIPTION
The release notes of the Libraries BOM to have Cloud Java libraries' new feature and bug fixes highlighted.


Screenshot:

![image](https://user-images.githubusercontent.com/28604/208471981-f25c9f93-0a2d-4a92-88b8-59ce2b0b0265.png)


The changes in the google-cloud-java monorepo is not in this pull request.
