### PR TITLE
fix: release note script to handle GITHUB_REF properly

### DIFF
--- a/.github/workflows/release-note-generation.yaml
+++ b/.github/workflows/release-note-generation.yaml
@@ -28,13 +28,15 @@ jobs:
         if [ -n "${WORKFLOW_DISPATCH_INPUT}" ]; then
           echo "WORKFLOW_DISPATCH_INPUT: ${WORKFLOW_DISPATCH_INPUT}"
           echo "libraries-bom-version=${WORKFLOW_DISPATCH_INPUT}" >> $GITHUB_OUTPUT
-        elif [ -n "${GITHUB_REF}" ]; then
+        elif [[ "${GITHUB_REF}" == *"libraries-bom"* ]]; then
           # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+          # Example value refs/tags/libraries-bom-v26.3.3
           echo "GITHUB_REF: ${GITHUB_REF}"
-          VERSION=${GITHUB_REF#refs/*/}
+          VERSION=${GITHUB_REF#refs/*/libraries-bom-v}
           echo "libraries-bom-version=${VERSION}" >> $GITHUB_OUTPUT
         else
-          echo "Couldn't find the Libraries BOM version. WORKFLOW_DISPATCH_INPUT and GITHUB_REF are empty."
+          echo "Couldn't find the Libraries BOM version. WORKFLOW_DISPATCH_INPUT \
+              was empty and GITHUB_REF was ${GITHUB_REF}."
           exit 1
         fi
       env:


### PR DESCRIPTION
Release note generation script failed for 26.3.0 release last week because it didn't handle the GITHUB_REF value properly:

<img width="1350" alt="Screenshot 2023-01-09 at 3 19 25 PM" src="https://user-images.githubusercontent.com/28604/211412398-439e4412-fa80-406a-895b-24dd2ecdc994.png">

This PR fixes it.