### PR TITLE
chore: preparing 26.1.x branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -6,3 +6,7 @@ branches:
     handleGHRelease: true
     bumpMinorPreMajor: true
     branch: java7
+  - releaseType: java-backport
+    manifest: true
+    handleGHRelease: true
+    branch: 26.1.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -24,7 +24,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (7)
@@ -40,7 +39,6 @@ branchProtectionRules:
       - dependencies (8)
       - dependencies (11)
       - lint
-      - clirr
       - units (8)
       - units (11)
       - cla/google

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -31,6 +31,20 @@ branchProtectionRules:
       - units (8)
       - units (11)
       - cla/google
+  - pattern: 26.1.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (8)
+      - dependencies (11)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - cla/google
+      - bom-content-test
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases