### PR TITLE
deps: overriding gax, protobuf, and bigquerystorage to patched versions

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -179,7 +179,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerystorage-bom</artifactId>
-        <version>2.25.0</version>
+        <version>2.25.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -60,10 +60,17 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <!-- overriding GAX version for libraries BOM 26.1.6 release -->
+        <!-- overriding GAX and Protobuf versions for Beam's dependency consistency -->
         <groupId>com.google.api</groupId>
         <artifactId>gax-bom</artifactId>
         <version>2.19.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>3.21.10</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -59,6 +59,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <!-- overriding GAX version for libraries BOM 26.1.6 release -->
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>2.19.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- first-party-dependencies is part of google-cloud-shared-dependencies
            BOM in https://github.com/googleapis/java-shared-dependencies/blob/main/first-party-dependencies/pom.xml.
            This includes Guava, Protobuf, gRPC, Google Auth Libraries, etc. -->


### PR DESCRIPTION
Overriding gax version to patched 2.19.6 in java-cloud-bom's 26.1.x branch.