### PR TITLE
chore: exclude requirement.txt in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
In this repository, renovate.json is excluded in owlbot.py.

As per discussion with @meltsufin , RenovateBot touching requirement.txt causes conflicts between RenovateBot and OwlBot Postprocessor. I'm excluding the file via renovate.json following what @mpeddada1 did in https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/java_library/renovate.json#L15