### PR TITLE
ci: fixing update release tag in release-note job

### DIFF
--- a/.github/workflows/release-note-generation.yaml
+++ b/.github/workflows/release-note-generation.yaml
@@ -65,7 +65,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
     - name: Update the release note with release_note.md
       run: |
-        TAG="libraries-bom-v${LIBRARIES_BOM_VERSION}"
+        TAG="v${LIBRARIES_BOM_VERSION}"
         echo "Updating ${TAG}"
         gh release edit "${TAG}" --notes-file release_note.md
       working-directory: release-note-generation


### PR DESCRIPTION
Previous attempt https://github.com/googleapis/java-cloud-bom/pull/5788 failed.

<img width="476" alt="Screenshot 2023-01-27 at 10 02 48 AM" src="https://user-images.githubusercontent.com/28604/215118145-8ddca856-792c-467d-a6cd-6c1a48d54655.png">

With single-component setup, the tag no longer carries "libraries-bom" prefix.