### PR TITLE
test: add duplicate class exclusion for gapic-generator-java artifact

### DIFF
--- a/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -146,6 +146,13 @@ public class BomContentTest {
         continue;
       }
 
+      if (currentArtifact.getGroupId().equals("com.google.api")
+          && currentArtifact.getGroupId().getArtifactId().equals("gapic-generator-java")) {
+        // Skip gapic-generator-java artifact, which is part of gapic-generator-java-bom
+        // but not intended to be client library user-facing
+        continue;
+      }
+
       String artifactCoordinates = Artifacts.toCoordinates(currentArtifact);
 
       for (String className : classPathEntry.getFileNames()) {


### PR DESCRIPTION
This PR adds an exclusion for the `gapic-generator-java` artifact in `assertUniqueClasses` to resolve issue from https://github.com/googleapis/java-cloud-bom/pull/5961#issuecomment-1530066593.

Context: `BOMContentTest` currently fails since inclusion of this artifact in `gapic-generator-java-bom` as of v2.18.0 ([googleapis/gapic-generator-java#1645](https://github.com/googleapis/gapic-generator-java/pull/1645)). `gapic-generator-java` is not intended for use by client libraries, and was added for downstream usage by the spring-cloud-gcp code generator (https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1686).
