### PR TITLE
deps: update dependency com.google.cloud:first-party-dependencies to v3.10.1

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>first-party-dependencies</artifactId>
-        <version>3.10.0</version>
+        <version>3.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Follow-up to PR https://github.com/googleapis/java-cloud-bom/pull/6000. PR 6000 is only updating the shared-dependencies version to 3.10.0. The desired version is 3.10.1.
