### PR TITLE
chore: fix Kokoko release stage job by replacing --activate-profiles with -P

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -43,7 +43,7 @@ retry_with_backoff 3 10 \
 # Then, release the staging repository
 if [[ -n "${AUTORELEASE_PR}" ]]
 then
-  mvn nexus-staging:release -B --activate-profiles release-staging-repository \
+  mvn nexus-staging:release -B -P release-staging-repository \
     -DperformRelease=true \
     --settings=settings.xml
 fi

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -15,6 +15,8 @@
 
 set -eo pipefail
 
+echo "HELLO"
+
 # Start the releasetool reporter
 requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
 python3 -m pip install --require-hashes -r $requirementsFile


### PR DESCRIPTION
Troubleshooting https://github.com/googleapis/java-cloud-bom/pull/6005.


