### PR TITLE
deps: update dependency com.google.cloud:google-cloud-storage-bom to v2.22.5

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -250,7 +250,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-bom</artifactId>
-        <version>2.22.4</version>
+        <version>2.22.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
manual create for v2.22.5.
release cut to maintain dependency consistency ([context](https://github.com/googleapis/google-cloud-java/pull/9573#issuecomment-1602935279)).