### PR TITLE
chore: update README table workflow to be able to be manually triggered

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -2,10 +2,10 @@ name: Update README with libraries-bom table
 # Run this workflow upon published release
 
 on:
+  workflow_dispatch:
   release:
     types:
     - published
-    workflow_dispatch:
 
 jobs:
   update-readme:


### PR DESCRIPTION
Fixes error in indentation of update README table workflow. This fix should enable the workflow to be manually triggered.