### PR TITLE
chore: add pyyaml installation step to workflow

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -20,6 +20,9 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Install dependencies
+      run: pip install pyyaml
+
     - name: Update table of artifacts
       run: |
         echo "Updating README.md with table of artifacts associated with the latest libraries-bom..."


### PR DESCRIPTION
Workflow failing due to missing `pyyaml` step: https://github.com/googleapis/java-cloud-bom/actions/runs/5647840842/job/15298785356

```
Traceback (most recent call last):
  File "/home/runner/work/java-cloud-bom/java-cloud-bom/libraries-bom-table-generation/updateREADMETable.py", line 3, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

This should fix that.