### PR TITLE
chore: update workflow to use branch instead of main

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -34,4 +34,11 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git add README.md
         git commit -m "Update README with release table"
-        git push
+        git checkout -b update-readme
+        git push origin update-readme
+
+    - name: Create Pull Request
+      run: |
+        gh pr create --base main --head update-readme --title "Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow failing: https://github.com/googleapis/java-cloud-bom/actions/runs/5648078883/job/15299506022 due to branch protection rules on `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: Changes must be made through a pull request. 8 of 8 required status checks are expected.        
To https://github.com/googleapis/java-cloud-bom
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/googleapis/java-cloud-bom'
```

This updates the workflow to push the PR from a separate branch.