### PR TITLE
chore: update workflow to generate PRs with correct commit prefix and use Cloud Java bot

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -30,10 +30,10 @@ jobs:
 
     - name: Commit and push changes
       run: |
-        git config --global user.name "GitHub Actions Bot"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "Cloud Java Bot"
+        git config --global user.email "cloud-java-bot@google.com"
         git add README.md
-        git commit -m "Update README with release table"
+        git commit -m "chore: update README with release table"
         git checkout -b update-readme
         git push origin update-readme
 
@@ -41,4 +41,4 @@ jobs:
       run: |
         gh pr create --base main --head update-readme --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -39,6 +39,6 @@ jobs:
 
     - name: Create Pull Request
       run: |
-        gh pr create --base main --head update-readme --title "Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
+        gh pr create --base main --head update-readme --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow currently generates PR without the correct prefix: https://github.com/googleapis/java-cloud-bom/pull/6115

It also uses the generic Github Actions Bot which does not pass the CLA check. Switching to use the Cloud Java bot