### PR TITLE
chore: update workflow to clean up branch

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -20,6 +20,11 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Delete existing 'update-readme-bot' branch
+      run: |
+        git push --delete origin update-readme-bot || echo "Branch doesn't exist, continuing..."
+        git branch -D update-readme-bot || echo "Branch doesn't exist, continuing..."
+
     - name: Install dependencies
       run: pip install pyyaml
 
@@ -34,8 +39,8 @@ jobs:
         git config --global user.email "cloud-java-bot@google.com"
         git add README.md
         git commit -m "chore: update README with release table"
-        git checkout -b update-readme
-        git push origin update-readme
+        git checkout -b update-readme-bot
+        git push origin update-readme-bot
 
     - name: Create Pull Request
       run: |


### PR DESCRIPTION
https://github.com/googleapis/java-cloud-bom/actions/runs/5659031293/job/15331677438

Workflow fails:

```
Switched to a new branch 'update-readme'
To https://github.com/googleapis/java-cloud-bom
 ! [rejected]        update-readme -> update-readme (fetch first)
error: failed to push some refs to 'https://github.com/googleapis/java-cloud-bom'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
```


This should clean it up by deleting the branch before re-creating it each time the README is updated.