### PR TITLE
chore: update workflow to use GH_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -46,4 +46,4 @@ jobs:
       run: |
         gh pr create --base main --head update-readme --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
       env:
-        GITHUB_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow failed: https://github.com/googleapis/java-cloud-bom/actions/runs/5659974377

```
Run gh pr create --base main --head update-readme --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```