### PR TITLE
chore: fix branch name in workflow

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -44,6 +44,6 @@ jobs:
 
     - name: Create Pull Request
       run: |
-        gh pr create --base main --head update-readme --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
+        gh pr create --base main --head update-readme-bot --title "chore: Update README with release table" --body "Updating README with the table of artifacts associated with the latest libraries-bom release"
       env:
-        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
should fix https://github.com/googleapis/java-cloud-bom/actions/workflows/update-readme-table.yaml creating PRs in the wrong branch name.