### PR TITLE
chore: Remove references to game-server module

### DIFF
--- a/libraries-bom-table-generation/javaModulesMetadata.yaml
+++ b/libraries-bom-table-generation/javaModulesMetadata.yaml
@@ -124,7 +124,6 @@ google-cloud-eventarc-publishing: https://cloud.google.com/eventarc/docs, Eventa
 google-cloud-filestore: https://cloud.google.com/filestore/docs, Cloud Filestore API
 google-cloud-firestore: https://cloud.google.com/firestore, Cloud Firestore
 google-cloud-functions: https://cloud.google.com/functions, Cloud Functions
-google-cloud-game-servers: https://cloud.google.com/docs/games/products/, Cloud Gaming
 google-cloud-gke-backup: https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke,
   Backup for GKE
 google-cloud-gke-connect-gateway: https://cloud.google.com/anthos/multicluster-management/gateway/,

--- a/tests/dependency-convergence/pom.xml
+++ b/tests/dependency-convergence/pom.xml
@@ -200,10 +200,6 @@
       <groupId>com.google.cloud</groupId>
     </dependency>
     <dependency>
-      <artifactId>google-cloud-game-servers</artifactId>
-      <groupId>com.google.cloud</groupId>
-    </dependency>
-    <dependency>
       <artifactId>google-cloud-gkehub</artifactId>
       <groupId>com.google.cloud</groupId>
     </dependency>


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-cloud-bom/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Error from the full-dependencies-check:
```
Error: ] Some problems were encountered while processing the POMs:
Error:  'dependencies.dependency.version' for com.google.cloud:google-cloud-game-servers:jar is missing. @ line 202, column 17
 @ 
Error:  The build could not read 1 project -> [Help 1]
Error:    
Error:    The project com.google.cloud:full-convergence-check:0.25.0 (/home/runner/work/java-cloud-bom/java-cloud-bom/tests/dependency-convergence/pom.xml) has 1 error
Error:      'dependencies.dependency.version' for com.google.cloud:google-cloud-game-servers:jar is missing. @ line 202, column [17](https://github.com/googleapis/java-cloud-bom/actions/runs/6645828051/job/18057979135?pr=6262#step:6:18)
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
Error: Process completed with exit code 1.
```

from: https://github.com/googleapis/java-cloud-bom/actions/runs/6645828051/job/18057979135?pr=6262