### PR TITLE
fix: specify artifact_id to replace explicitly.

### DIFF
--- a/.kokoro/nightly/create-versions-csv.sh
+++ b/.kokoro/nightly/create-versions-csv.sh
@@ -38,8 +38,11 @@ cat libraries.txt | while read line; do
   new_group_id="${group_id//.//}"
   service_name=${artifact_id#*-cloud-}
 
-  if [[ "${artifact_id}" == *storage* ]]; then
+  if [[ "${artifact_id}" == google-cloud-storage ]]; then
     service_name=bigstore
+  fi
+  if [[ "${artifact_id}" == google-cloud-storage-transfer ]]; then
+    service_name=storagetransfer
   fi
 
   URL=https://repo1.maven.org/maven2/$new_group_id/$artifact_id


### PR DESCRIPTION
This change should fix the issue that all these 4 artifacts are mapped to service "bigstore".

```
google-cloud-bigquerystorage 
google-cloud-storage
google-cloud-storage-transfer
google-cloud-storageinsights # I was not able to find corresponding log items
```