### PR TITLE
fix(libraries-release-data): add spring autogen to tracked libraries.

### DIFF
--- a/.kokoro/nightly/create-versions-csv.sh
+++ b/.kokoro/nightly/create-versions-csv.sh
@@ -77,9 +77,11 @@ while IFS= read -r line; do
     ../.kokoro/nightly/fetch-library-data.sh $URL $artifact_id $service_name >> cloud_java_client_library_release_dates.csv
 done < "$apiary_list"
 
-# add spring cloud gcp, "service_name" is tool_name
+# add spring cloud gcp and autogen, "service_name" is tool_name
 ../.kokoro/nightly/fetch-library-data.sh https://repo1.maven.org/maven2/com/google/cloud/spring-cloud-gcp-dependencies/ spring-cloud-gcp-dependencies spring-cloud-gcp >> cloud_java_client_library_release_dates.csv
 ../.kokoro/nightly/fetch-library-data.sh https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-gcp-dependencies/ spring-cloud-gcp-dependencies spring-cloud-gcp >> cloud_java_client_library_release_dates.csv
+
+../.kokoro/nightly/fetch-library-data.sh https://repo1.maven.org/maven2/com/google/cloud/google-cloud-language-spring-starter/ google-cloud-language-spring-starter spring-autogen >> cloud_java_client_library_release_dates.csv
 
 rm -f libraries.txt
 rm -f artifacts_to_services_apiary.txt


### PR DESCRIPTION
These preview modules need to be tracked too. They have different versions (e.g. [4.7.2-preview](https://repo1.maven.org/maven2/com/google/cloud/google-cloud-language-spring-starter/4.7.2-preview/)) than spring-cloud-gcp.
Because there is no module that is unique to and all preview module depend on, use `google-cloud-language-spring-starter` to track versions. (this module is also used in spring-generator manual tests)