### PR TITLE
Revert "build(deps): update dependency org.apache.maven.resolver:maven-resolver-api to v2"

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>
-      <version>2.0.0</version>
+      <version>1.9.20</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Reverts googleapis/java-cloud-bom#6671

This is a major version bump and cause the dashboard ci failed:
```
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:java (default-cli) on project google-cloud-bom-dashboard: An exception occured while executing the Java class. org.codehaus.plexus.component.repository.exception.ComponentLookupException: com.google.inject.ProvisionException: Unable to provision, see the following errors:
Error:  
Error:  1) null returned by binding at org.eclipse.sisu.wire.LocatorWiring
Error:   but the 7th parameter of org.eclipse.aether.internal.impl.DefaultRepositorySystem.<init>(Unknown Source) is not @Nullable
Error:    at org.eclipse.sisu.wire.LocatorWiring
Error:    while locating org.eclipse.aether.impl.Installer
Error:      for the 7th parameter of org.eclipse.aether.internal.impl.DefaultRepositorySystem.<init>(Unknown Source)
Error:    while locating org.eclipse.aether.internal.impl.DefaultRepositorySystem
Error:    while locating java.lang.Object annotated with *
Error:    while locating org.apache.maven.artifact.resolver.DefaultArtifactResolver
Error:    at ClassRealm[plexus.core, parent: null] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
Error:    while locating org.apache.maven.artifact.resolver.ArtifactResolver
Error:    while locating org.apache.maven.repository.legacy.LegacyRepositorySystem
Error:    at ClassRealm[plexus.core, parent: null] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
Error:    while locating org.apache.maven.repository.RepositorySystem
Error:    while locating org.apache.maven.project.DefaultProjectBuildingHelper
Error:    at ClassRealm[plexus.core, parent: null] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
Error:    while locating org.apache.maven.project.ProjectBuildingHelper
Error:    while locating org.apache.maven.project.DefaultProjectBuilder
Error:    at ClassRealm[plexus.core, parent: null] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
Error:    while locating org.apache.maven.project.ProjectBuilder
Error: [ERROR] 
Error: [ERROR] 1 error
Error:        role: org.apache.maven.project.ProjectBuilder
Error:    roleHint:
```