### PR TITLE
chore: update link to Google Cloud Shared Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ This is the table of modules included in the latest libraries-bom release:
 
 The [google-cloud-bom dashboard](https://storage.googleapis.com/java-cloud-bom-dashboard/com.google.cloud/google-cloud-bom/all-versions/index.html) provides client library consumers with easy access to dependency information pertaining to each client library that goes into the google-cloud-bom.
 
-The dashboard shows the content of **each version** of the BOM which includes all the versions of the artifacts in it and their underlying [google-cloud-shared-dependencies BOM](https://github.com/googleapis/java-shared-dependencies#google-cloud-shared-dependencies) version.
+The dashboard shows the content of **each version** of the BOM which includes all the versions of the artifacts in it and their underlying [google-cloud-shared-dependencies BOM](https://github.com/googleapis/sdk-platform-java/tree/main/java-shared-dependencies) version.
 
 The dashboard also has an [all versions](https://storage.googleapis.com/java-cloud-bom-dashboard/com.google.cloud/google-cloud-bom/all-versions/index.html) page where user can easily search on any artifact or version to see which version of the google-cloud-bom it exists in -- this could be helpful in providing client library consumer advice on which version(s) of google-cloud-bom to import to address their needs.
 


### PR DESCRIPTION
Link to Google Cloud Shared Dependencies points to archived repo. Update to maintained project.