### PR TITLE
chore: Override the version of protobuf-bom to 4.28.3 in libraries-bom.

### DIFF
--- a/libraries-bom-protobuf3/pom.xml
+++ b/libraries-bom-protobuf3/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom-protobuf3</artifactId>
-  <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom-protobuf3:current} -->
+  <version>26.50.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom-protobuf3:current} -->
   <packaging>pom</packaging>
 
   <parent>

--- a/libraries-bom-protobuf3/pom.xml
+++ b/libraries-bom-protobuf3/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom-protobuf3</artifactId>
-  <version>26.50.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom-protobuf3:current} -->
+  <version>26.50.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom:current} -->
   <packaging>pom</packaging>
 
   <parent>

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -59,6 +59,17 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- This section overrides the protobuf version specified in first-party-dependencies. This is to provide customers a bom that includes protobuf-java 4.x.
+      We will upgrade protobuf-bom in first-party-dependencies once we feel comfortable that most customers would not have conflict with protobuf-java 4.x.
+      This section has to be specified before first-party-dependencies, please do not move it. -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>4.28.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- first-party-dependencies is part of java-shared-dependencies
            BOM in https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml.
            This includes Guava, Protobuf, gRPC, Google Auth Libraries, etc. -->

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -183,7 +183,7 @@ public class ReleaseNoteGeneration {
         .append(versionlessCoordinatesToVersion.get("com.google.cloud:google-cloud-core"))
         .append("\n");
     report
-        .append("If you encounter compatibility issues with protobuf-java 4.x, please update your codebase and dependencies to ensure compatibility. If this is not feasible, as a workaround, use libraries-bom-protobuf3 which is compatible with protobuf-java 3.x. libraries-bom-protobuf3 includes the same client libraries and library versions as libraries-bom.")
+        .append("If you encounter compatibility issues with protobuf-java 4.x, please update your codebase and dependencies to ensure compatibility. If this is not feasible, use libraries-bom-protobuf3 as a workaround. libraries-bom-protobuf3 includes the same client libraries and library versions as libraries-bom.")
         .append("\n");
   }
 

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -183,7 +183,7 @@ public class ReleaseNoteGeneration {
         .append(versionlessCoordinatesToVersion.get("com.google.cloud:google-cloud-core"))
         .append("\n");
     report
-        .append("If you encounter compatibility issues with protobuf-java 4.x, please update your codebase and dependencies to ensure compatibility. If this is not feasible, you may use libraries-bom-protobuf3 as a workaround. This option utilizes protobuf-java 3.x and provides the same client libraries as libraries-bom.")
+        .append("If you encounter compatibility issues with protobuf-java 4.x, please update your codebase and dependencies to ensure compatibility. If this is not feasible, as a workaround, use libraries-bom-protobuf3 which is compatible with protobuf-java 3.x. libraries-bom-protobuf3 includes the same client libraries and library versions as libraries-bom.")
         .append("\n");
   }
 

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -182,6 +182,9 @@ public class ReleaseNoteGeneration {
         .append("- Google Cloud Core: ")
         .append(versionlessCoordinatesToVersion.get("com.google.cloud:google-cloud-core"))
         .append("\n");
+    report
+        .append("If you encounter compatibility issues with protobuf-java 4.x, please update your codebase and dependencies to ensure compatibility. If this is not feasible, you may use libraries-bom-protobuf3 as a workaround. This option utilizes protobuf-java 3.x and provides the same client libraries as libraries-bom.")
+        .append("\n");
   }
 
   private void printApiReferenceLink() {

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,12 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "matchPackagePatterns": [
+        "^com.google.protobuf:"
+      ],
+      "enabled": false
     }
   ],
   "semanticCommits": "enabled",

--- a/versions.txt
+++ b/versions.txt
@@ -3,6 +3,6 @@
 
 google-cloud-bom:0.230.0:0.231.0-SNAPSHOT
 libraries-bom:26.49.0:26.50.0-SNAPSHOT
-libraries-bom-protobuf3:0.1.0:0.2.0-SNAPSHOT
+libraries-bom-protobuf3:26.49.0:26.50.0-SNAPSHOT
 java-cloud-bom-tests:0.45.0:0.46.0-SNAPSHOT
 full-convergence-check:0.48.0:0.49.0-SNAPSHOT

--- a/versions.txt
+++ b/versions.txt
@@ -3,6 +3,5 @@
 
 google-cloud-bom:0.230.0:0.231.0-SNAPSHOT
 libraries-bom:26.49.0:26.50.0-SNAPSHOT
-libraries-bom-protobuf3:26.49.0:26.50.0-SNAPSHOT
 java-cloud-bom-tests:0.45.0:0.46.0-SNAPSHOT
 full-convergence-check:0.48.0:0.49.0-SNAPSHOT


### PR DESCRIPTION
In this PR:
- Add a new `protobuf-bom` section to `libraries-bom` to override the protobuf runtime version to the latest.
- Add a new generated release notes to direct customers to use `libraries-bom-protobuf3` if there is any incompatibility issues.
- Update the version of `libraries-bom-protobuf3` to match the version of `libraries-bom`.
- Disables `protobuf-bom` from being updated by renovate bot.