### PR TITLE
chore: Add documentation for libraries-bom-protobuf3 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To use it in Maven, add the following to your POM:
 When you use the Libraries BOM, you don't specify individual library versions
 and your application runs on a consistent set of the dependencies.
 
+If you encounter compatibility issues with protobuf-java 4.x, update your codebase and dependencies to ensure compatibility, see [release notes of libraries-bom v26.50.0](https://github.com/googleapis/java-cloud-bom/releases/tag/v26.50.0) for potential compatibility issues. If this is not feasible, use `com.google.cloud:libraries-bom-protobuf3` as a workaround. `com.google.cloud:libraries-bom-protobuf3` includes the same client libraries and library versions as libraries-bom.
+
 ## Libraries in Scope
 
 The content of the Libraries BOM consists of 2 categories:


### PR DESCRIPTION
Starting [libraries-bom v26.50.0](https://github.com/googleapis/java-cloud-bom/releases/tag/v26.50.0), we release two boms: libraries-bom that includes protobuf-java runtime 4.x, and libraries-bom-protobuf3 that includes protobuf-java runtime 3.x. libraries-bom is still the preferred solution, libraries-bom-protobuf3 is a backup solution only for customers that have conflicts with protobuf-java runtime 3.x.

See [go/cloud-sdk-java-protobuf-upgrade-strategy-design](https://goto.google.com/cloud-sdk-java-protobuf-upgrade-strategy-design) for details.