### PR TITLE
deps: update protobuf to 4.29.0

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -207,7 +207,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging-bom</artifactId>
-        <version>3.21.0</version>
+        <version>3.21.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -193,7 +193,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastore-bom</artifactId>
-        <version>2.25.1</version>
+        <version>2.25.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -231,7 +231,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-pubsublite-bom</artifactId>
-        <version>1.15.0</version>
+        <version>1.15.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -174,7 +174,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>2.45.0</version>
+        <version>2.46.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -200,7 +200,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-firestore-bom</artifactId>
-        <version>3.30.2</version>
+        <version>3.30.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -186,7 +186,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>
-        <version>2.51.0</version>
+        <version>2.51.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -219,7 +219,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-nio</artifactId>
-        <version>0.127.28</version>
+        <version>0.127.29</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -179,7 +179,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerystorage-bom</artifactId>
-        <version>3.11.0</version>
+        <version>3.11.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -238,7 +238,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.83.0</version>
+        <version>6.85.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -245,7 +245,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-jdbc</artifactId>
-        <version>2.25.1</version>
+        <version>2.26.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-pubsub-bom</artifactId>
-        <version>1.135.0</version>
+        <version>1.136.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -167,7 +167,7 @@
         <!-- Artifacts from google-cloud-java monorepo -->
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>
-        <version>1.49.0</version>
+        <version>1.50.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -250,7 +250,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-bom</artifactId>
-        <version>2.46.0</version>
+        <version>2.47.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -214,7 +214,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging-logback</artifactId>
-        <version>0.132.0-alpha</version>
+        <version>0.132.1-alpha</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-bom</artifactId>
-        <version>4.28.3</version>
+        <version>4.29.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>first-party-dependencies</artifactId>
-        <version>3.41.0</version>
+        <version>3.41.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Tested externally using:
[linkage checker](https://github.com/lqiu96/gapic-generator-java/actions/runs/12772035369)
[protobuf nightly check](https://github.com/googleapis/sdk-platform-java/actions/runs/12770706829)
[manual linkage checker for mono repo](https://paste.googleplex.com/4563607153803264)