### PR TITLE
ci: grant permissions to release note generation workflow

### DIFF
--- a/.github/workflows/release-note-generation.yaml
+++ b/.github/workflows/release-note-generation.yaml
@@ -13,6 +13,9 @@ name: release-notes
 jobs:
   release-note-generation:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4


### PR DESCRIPTION
Similar to https://github.com/googleapis/google-cloud-java/pull/11503