### PR TITLE
ci: grant permission to update-readme workflow

### DIFF
--- a/.github/workflows/update-readme-table.yaml
+++ b/.github/workflows/update-readme-table.yaml
@@ -10,7 +10,9 @@ on:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - name: Check out repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The workflow has been failing due to organization-wide permission change. https://github.com/googleapis/java-cloud-bom/actions/workflows/update-readme-table.yaml: 

![image](https://github.com/user-attachments/assets/80baca9e-86ec-4260-8b84-f2b0f985308b)
