### PR TITLE
deps: Upgrade Protobuf-Java to v3.25.8

### DIFF
--- a/libraries-bom-protobuf3/pom.xml
+++ b/libraries-bom-protobuf3/pom.xml
@@ -25,7 +25,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-bom</artifactId>
-        <version>3.25.5</version>
+        <version>3.25.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
update protobuf version for libraries-bom-protobuf3. 

Merge when upstream changes are in.