### PR TITLE
test(spanner): add Spanner test workflow for express release train

### DIFF
--- a/.github/workflows/spanner.yaml
+++ b/.github/workflows/spanner.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+name: spanner
+jobs:
+  units:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: tests/spanner/test-spanner.sh

--- a/tests/spanner/test-spanner.sh
+++ b/tests/spanner/test-spanner.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+SPANNER_VERSION=$(awk '/<artifactId>google-cloud-spanner-bom<\/artifactId>/{f=1;next} /<version>/{if(f){print;exit}}' google-cloud-bom/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p')
+FIRST_PARTY_DEPENDENCIES_VERSION=$(awk '/<artifactId>first-party-dependencies<\/artifactId>/{f=1;next} /<version>/{if(f){print;exit}}' libraries-bom/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p')
+
+echo "google-cloud-spanner-bom version: $SPANNER_VERSION"
+echo "first-party-dependencies version: $FIRST_PARTY_DEPENDENCIES_VERSION"
+
+# Download spanner source code
+rm -rf java-spanner
+git clone --depth 1 --branch v${SPANNER_VERSION} -c advice.detachedHead=false https://github.com/googleapis/java-spanner.git
+
+# Update the version of sdk-platform-java-config in all pom.xml files
+for pom_file in $(find java-spanner -name "pom.xml"); do
+  if grep -q "<artifactId>sdk-platform-java-config</artifactId>" "$pom_file"; then
+    awk -v version="${FIRST_PARTY_DEPENDENCIES_VERSION}" '
+      /<artifactId>sdk-platform-java-config<\/artifactId>/ {
+        print
+        getline # Read the next line (which should be the version)
+        print "    <version>" version "</version>"
+        next
+      }
+      { print }
+    ' "$pom_file" > "$pom_file.tmp" && mv "$pom_file.tmp" "$pom_file"
+    echo "Updated: $pom_file"
+  fi
+done
+
+# Show the diffs
+echo "Changes after version updates:"
+(cd java-spanner && git add .)
+(cd java-spanner && git --no-pager diff --staged)
+
+# Clean up backup files
+find java-spanner -name "pom.xml.bak" -delete
+
+(cd java-spanner && JOB_TYPE=test .kokoro/build.sh)


### PR DESCRIPTION
Introduces a new GitHub Actions workflow to perform compatibility testing with the Spanner library analogous to the release train.

The workflow utilizes a new shell script (`tests/spanner/test-spanner.sh`) that downloads the `java-spanner` repository at the version that is currently in the Libraries BOM, updates its `sdk-platform-java-config` dependency version to also match the version in the Libraries BOM, and executes the Spanner build process.

In this commit we are only running the Spanner unit tests, but this can later be expanded to include integration tests.