### PR TITLE
chore: add release-please config for protobuf-4.x

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -11,3 +11,7 @@ branches:
     manifest: true
     handleGHRelease: true
     branch: 26.1.x
+  - releaseType: java-yoshi
+    manifest: true
+    handleGHRelease: true
+    branch: protobuf-4.x-rc


### PR DESCRIPTION
[go/cloud-java:protobuf-4.x-upgrade](http://goto.google.com/cloud-java:protobuf-4.x-upgrade)

Config in https://github.com/googleapis/java-cloud-bom/blob/protobuf-4.x-rc/release-please-config.json