### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,10 +3,10 @@ handleGHRelease: true
 manifest: true
 primaryBranch: main
 branches:
-    - releaseType: java-yoshi
+    - branch: java7
+      releaseType: java-yoshi
       bumpMinorPreMajor: true
-      branch: java7
-    - releaseType: java-backport
-      branch: 26.1.x
-    - releaseType: java-yoshi
-      branch: protobuf-4.x-rc
+    - branch: 26.1.x
+      releaseType: java-backport
+    - branch: protobuf-4.x-rc
+      releaseType: java-yoshi


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.