### PR TITLE
deps: Update first-party-dependencies to 3.55.0-rc1

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -44,7 +44,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <first-party-dependencies.version>3.54.2</first-party-dependencies.version>
+    <first-party-dependencies.version>3.55.0-rc1</first-party-dependencies.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
We missed to update first-party-dependencies to 3.55.0-rc1 on protobuf-4.x-rc branch. This would cause enforcer errors such as 
```
[ERROR] Failed while enforcing RequireUpperBoundDeps. The error(s) are [
[ERROR] Require upper bound dependencies error for com.google.http-client:google-http-client-appengine:2.0.2. Paths to dependency are:
[ERROR]   +-com.google.cloud:google-cloud-datastore:2.34.0-rc1
[ERROR]     +-com.google.http-client:google-http-client-appengine:2.0.2 (managed) <-- com.google.http-client:google-http-client-appengine:2.1.0-rc1
```