### PR TITLE
build: Remove the explicit override for protobuf 4.x version. 

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -60,17 +60,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- This section overrides the protobuf version specified in first-party-dependencies. This is to provide customers a bom that includes protobuf-java 4.x.
-      We will upgrade protobuf-bom in first-party-dependencies once we feel comfortable that most customers would not have conflict with protobuf-java 4.x.
-      This section has to be specified before first-party-dependencies, please do not move it. -->
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-bom</artifactId>
-        <version>4.33.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <!-- first-party-dependencies is part of java-shared-dependencies
            BOM in https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml.
            This includes Guava, Protobuf, gRPC, Google Auth Libraries, etc. -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <!-- Only modules to be published to Maven Central. No tests or release note generation. -->
     <module>google-cloud-bom</module>
     <module>libraries-bom</module>
-    <module>libraries-bom-protobuf3</module>
   </modules>
 
   <build>


### PR DESCRIPTION
protobuf-java version has already been upgrade to 4.x in [sdk-platform-java](https://github.com/googleapis/sdk-platform-java/blob/65078428c82b40bfd98d0315795338f6f1e59164/gapic-generator-java-pom-parent/pom.xml#L35), there is no need to override it anymore in the bom. Remove the explicit override for protobuf 4.x version.  

Separately, stop releasing libraries-bom-protobuf3 because it will be no longer compatible with the 4.x gen code.
