### PR TITLE
chore: Remove explictly declared grpc-gcp version

### DIFF
--- a/libraries-bom/pom.xml
+++ b/libraries-bom/pom.xml
@@ -79,11 +79,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>grpc-gcp</artifactId>
-        <version>1.9.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
grpc-gcp was explicitly declared in libraries-bom to resolve a dependency conflict issue. Now that grpc-gcp version is upgraded in [sdk-platform-java](https://github.com/googleapis/sdk-platform-java/pull/4025/changes) and removed in [java-spanner](https://github.com/googleapis/java-spanner/pull/4303), we can remove it from libraires-bom now.