### PR TITLE
chore: updating splitRepositoryLibraryNames in release-note-generation

### DIFF
--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -64,13 +64,7 @@ public class ReleaseNoteGeneration {
 
   private static final ImmutableSet<String> splitRepositoryLibraryNames =
       ImmutableSet.of(
-          "bigquery",
-          "bigquerystorage",
-          "bigtable",
-          "datastore",
           "firestore",
-          "logging",
-          "logging-logback",
           "logging-servlet-initializer",
           "pubsub",
           "pubsublite",


### PR DESCRIPTION
Some repositories have migrated to the google-cloud-java monorepo. Let's update the splitRepositoryLibraryNames so that the release note generation logic can point to correct repositories.
