### PR TITLE
chore: Remove newly migrated repos from BOM

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -173,11 +173,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bigquery</artifactId>
-        <version>2.62.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>
         <version>2.75.1</version>
         <type>pom</type>
@@ -208,18 +203,6 @@
         <version>1.16.3</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.113.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner-jdbc</artifactId>
-        <version>2.35.5</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -206,6 +206,11 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner-jdbc</artifactId>
+        <version>2.35.5</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-bom</artifactId>
         <version>2.64.1</version>
         <type>pom</type>


### PR DESCRIPTION
Looks like spanner-jdbc is not part of the gapic-libraries-bom