### PR TITLE
chore: Add vertex-ai to google-cloud-bom explicitly

### DIFF
--- a/google-cloud-bom/pom.xml
+++ b/google-cloud-bom/pom.xml
@@ -228,6 +228,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-vertexai-bom</artifactId>
+        <!-- This version is for backward compatibility only, it is fixed and should not be updated -->
+        <version>1.48.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This is a follow up of https://github.com/googleapis/google-cloud-java/pull/12691.