### PR TITLE
build: fix release notes generation for migrated libraries

### DIFF
--- a/release-note-generation/pom.xml
+++ b/release-note-generation/pom.xml
@@ -42,7 +42,6 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>32.1.3-jre</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/release-note-generation/pom.xml
+++ b/release-note-generation/pom.xml
@@ -38,6 +38,12 @@
 			<version>1.4.5</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>32.1.3-jre</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -45,6 +51,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
 				<configuration>
 					<skip>false</skip>
 					<mainClass>com.google.cloud.ReleaseNoteGeneration</mainClass>

--- a/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -64,20 +64,10 @@ public class ReleaseNoteGeneration {
 
   private static final ImmutableSet<String> splitRepositoryLibraryNames =
       ImmutableSet.of(
-          "bigquery",
-          "bigquerystorage",
           "bigtable",
-          "datastore",
           "firestore",
-          "logging",
-          "logging-logback",
-          "logging-servlet-initializer",
           "pubsub",
-          "pubsublite",
-          "spanner",
-          "spanner-jdbc",
-          "storage",
-          "storage-nio");
+          "pubsublite");
 
   private static boolean clientLibraryFilter(String coordinates) {
     if (coordinates.contains("google-cloud-core")) {

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -167,4 +167,5 @@ public class ReleaseNoteGenerationTest {
                 + " ([#1790](https://github.com/googleapis/java-storage/issues/1790)) "
                 + "([31c1b18](https://github.com/googleapis/java-storage/commit/31c1b18acc3c118e39eb613a82ee292f3e246b8f))");
   }
+
 }

--- a/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
+++ b/release-note-generation/src/test/java/com/google/cloud/ReleaseNoteGenerationTest.java
@@ -83,9 +83,9 @@ public class ReleaseNoteGenerationTest {
     Truth.assertThat(report)
         .contains(
             "- google-cloud-logging:3.13.1 (prev:3.12.0; Release Notes: "
-                + "[v3.12.1](https://github.com/googleapis/java-logging/releases/tag/v3.12.1), "
-                + "[v3.13.0](https://github.com/googleapis/java-logging/releases/tag/v3.13.0), "
-                + "[v3.13.1](https://github.com/googleapis/java-logging/releases/tag/v3.13.1))");
+                + "[v3.12.1](https://github.com/googleapis/google-cloud-java/releases/tag/v1.1.0), "
+                + "[v3.13.0](https://github.com/googleapis/google-cloud-java/releases/tag/v1.1.0), "
+                + "[v3.13.1](https://github.com/googleapis/google-cloud-java/releases/tag/v1.1.0))");
   }
 
   @Test


### PR DESCRIPTION
- Remove migrated libraries (bigquery, spanner, storage, datastore, logging) from the hardcoded split list in ReleaseNoteGeneration.java to prevent "release not found" crashes.
- Add explicit test dependency on Guava 32.1.3-jre in release-note-generation/pom.xml to fix conflicts with Truth.
- Add version 3.1.0 to exec-maven-plugin in release-note-generation/pom.xml.
- Update ReleaseNoteGenerationTest to expect monorepo links for logging.

Fixes #7466